### PR TITLE
Optional Frame IDs for mirte_telemetrix sensor

### DIFF
--- a/mirte_telemetrix/config/mirte_master_config_goede_arm.yaml
+++ b/mirte_telemetrix/config/mirte_master_config_goede_arm.yaml
@@ -122,24 +122,28 @@ distance:
   left_front:
     name: left_front
     device: mirte
+    frame_id: base_sonar_left_front
     pins:
       trigger: 6
       echo: 7
   left_rear:
     name: left_rear
     device: mirte
+    frame_id: base_sonar_left_rear
     pins:
       trigger: 8
       echo: 9
   right_front:
     name: right_front
     device: mirte
+    frame_id: base_sonar_right_front
     pins:
       trigger: 10
       echo: 11
   right_rear:
     name: right_rear
     device: mirte
+    frame_id: base_sonar_right_rear
     pins:
       trigger: 12
       echo: 13

--- a/mirte_telemetrix/scripts/ROS_telemetrix_aio_api.py
+++ b/mirte_telemetrix/scripts/ROS_telemetrix_aio_api.py
@@ -150,6 +150,7 @@ class SensorMonitor:
         self.differential = 0
         if "differential" in sensor:
             self.differential = sensor["differential"]
+        get_obj_value(self, sensor, "frame_id")
         self.loop = asyncio.get_event_loop()
         self.last_publish_time = -1
         self.last_publish_value = {}
@@ -163,6 +164,8 @@ class SensorMonitor:
     def get_header(self):
         header = Header()
         header.stamp = rospy.Time.now()
+        # TODO: Is a check for None needed here?
+        header.frame_id = self.frame_id
         return header
 
     # NOTE: although there are no async functions in this

--- a/mirte_telemetrix/scripts/ROS_telemetrix_aio_api.py
+++ b/mirte_telemetrix/scripts/ROS_telemetrix_aio_api.py
@@ -59,6 +59,7 @@ def get_obj_value(s, obj, key, def_value=None):
         if def_type == bool:
             out = bool(out)
     setattr(s, key, out)
+    return key in obj  # return if the key was found in the object
 
 
 # Import ROS message types
@@ -140,7 +141,7 @@ def get_pin_numbers(component):
 
 # Abstract Sensor class
 class SensorMonitor:
-    def __init__(self, board, sensor, publisher):
+    def __init__(self, board, sensor, publisher, frame_prefix=""):
         self.board = board
         self.pins = get_pin_numbers(sensor)
         self.publisher = publisher
@@ -150,7 +151,9 @@ class SensorMonitor:
         self.differential = 0
         if "differential" in sensor:
             self.differential = sensor["differential"]
-        get_obj_value(self, sensor, "frame_id")
+
+        if not get_obj_value(self, sensor, "frame_id"):
+            self.frame_id = f'{frame_prefix}_{sensor["name"]}'
         self.loop = asyncio.get_event_loop()
         self.last_publish_time = -1
         self.last_publish_value = {}
@@ -200,7 +203,7 @@ class KeypadMonitor(SensorMonitor):
         srv = rospy.Service(
             "/mirte/get_keypad_" + sensor["name"], GetKeypad, self.get_data
         )
-        super().__init__(board, sensor, pub)
+        super().__init__(board, sensor, pub, "keypad")
         self.last_debounce_time = 0
         self.last_key = ""
         self.last_debounced_key = ""
@@ -271,7 +274,7 @@ class DistanceSensorMonitor(SensorMonitor):
         srv = rospy.Service(
             "/mirte/get_distance_" + sensor["name"], GetDistance, self.get_data
         )
-        super().__init__(board, sensor, self.pub)
+        super().__init__(board, sensor, self.pub, "distance")
         self.last_publish_value = Range()
         self.name = sensor["name"]
 
@@ -300,6 +303,7 @@ class DistanceSensorMonitor(SensorMonitor):
         self.range.max_range = 1.5
         self.range.header = self.get_header()
         self.range.range = data[2] / 100.0  # convert from cm to m
+        self.range.header = self.get_header()
         self.pub.publish(self.range)
 
     def publish_data(self, event=None):
@@ -323,7 +327,7 @@ class DigitalIntensitySensorMonitor(SensorMonitor):
             GetIntensityDigital,
             self.get_data,
         )
-        super().__init__(board, sensor, pub)
+        super().__init__(board, sensor, pub, "intensity_digital")
         self.last_publish_value = IntensityDigital()
 
     def get_data(self, req):
@@ -349,7 +353,7 @@ class AnalogIntensitySensorMonitor(SensorMonitor):
         srv = rospy.Service(
             "/mirte/get_intensity_" + sensor["name"], GetIntensity, self.get_data
         )
-        super().__init__(board, sensor, pub)
+        super().__init__(board, sensor, pub, "intensity")
         self.last_publish_value = Intensity()
 
     def get_data(self, req):
@@ -380,7 +384,7 @@ class EncoderSensorMonitor(SensorMonitor):
         self.speed_pub = rospy.Publisher(
             "/mirte/encoder_speed/" + sensor["name"], Encoder, queue_size=1, latch=True
         )
-        super().__init__(board, sensor, pub)
+        super().__init__(board, sensor, pub, "encoder")
         self.ticks_per_wheel = 20
         if "ticks_per_wheel" in sensor:
             self.ticks_per_wheel = sensor["ticks_per_wheel"]
@@ -1716,6 +1720,8 @@ class Hiwonder_Servo:
             self.min_angle_in = -self.max_angle_in
             self.max_angle_in = -t
         print("rad range", self.name, [self.min_angle_in, self.max_angle_in])
+        if not get_obj_value(self, servo_obj, "frame_id"):
+            self.frame_id = f"servo_{self.name}"
 
     async def start(self):
         server = rospy.Service(
@@ -1780,7 +1786,7 @@ class Hiwonder_Servo:
         )
         header = Header()
         header.stamp = rospy.Time.now()
-
+        header.frame_id = self.frame_id
         position = ServoPosition()
         position.header = header
         position.raw = data["angle"]

--- a/mirte_telemetrix/scripts/modules/MPU9250.py
+++ b/mirte_telemetrix/scripts/modules/MPU9250.py
@@ -41,6 +41,12 @@ class MPU9250:
         self.imu_publisher = rospy.Publisher(
             f"/mirte/{self.name}/imu", Imu, queue_size=1
         )
+
+        if "frame_id" in self.module:
+            self.frame_id = self.module["frame_id"]
+        else:
+            self.frame_id = f"imu_{self.name}"
+
         # self.i2c_port = 0
         # TODO: no support yet for other addresses than 0x68
         await self.board.sensors.add_mpu9250(self.i2c_port, self.callback)
@@ -90,6 +96,8 @@ class MPU9250:
             angular_velocity_covariance=[-1, 0, 0, 0, 0, 0, 0, 0, 0],
             linear_acceleration_covariance=[-1, 0, 0, 0, 0, 0, 0, 0, 0],
         )
+        self.last_message.header.stamp = rospy.Time.now()
+        self.last_message.header.frame_id = self.frame_id
         self.imu_publisher.publish(self.last_message)
 
     def get_imu_service(self, req):


### PR DESCRIPTION
Add the ability to set a `frame_id` for the sensors connected via the telemetrix based on their `frame_id` parameter.

~(This code is untested since I don't have access to a mirte right now, will test tomorrow)~
Tested and functional