### PR TITLE
Mirte master namespace-able

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,26 @@
 # API
 
-The motors are controlled with PWM as as service. By default the topic published by the ROS diff_drive_controller (/mobile_base_controller/cmd_vel) will call that service. One has to disable the ROS diff_drive_controller () to manually set the PWM signal by using the service (eg from commandline).
+The motors are controlled with PWM as as service. By default the topic published by the ROS diff_drive_controller (`mobile_base_controller/cmd_vel`) will call that service. One has to disable the ROS diff_drive_controller () to manually set the PWM signal by using the service (eg from commandline).
 Currently, the default parameters are set to use the Mirte Arduino-nano PCB.
 
 ## Subscribed Topics
-/mobile_base_controller/cmd_vel (geometry_msgs/Twist)
+`mobile_base_controller/cmd_vel` (geometry_msgs/Twist)
 
 ## Published Topics
 Topics published to depend on the parameters given.
 
-/mirte/<name>_distance (sensor_msgs/Range)
-/mirte/<name>_encoder (mirte_msgs/Encoder)
-/mirte/<name>_intensity (mirte_msgs/Intensity)
+`mirte/<name>_distance` (sensor_msgs/Range)
+`mirte/<name>_encoder` (mirte_msgs/Encoder)
+`mirte/<name>_intensity` (mirte_msgs/Intensity)
 
 ## Services
-/mirte_navigation/move
-/mirte_navigation/turn
-/mirte_pymata/set_<name>_motor_pwm
-/mirte/get_pin_value
-/mirte/set_pin_mode
-/mirte/set_pin_value
-/mirte_service_api/get_<topic_name>
+`mirte_navigation/move`
+`mirte_navigation/turn`
+`mirte_pymata/set_<name>_motor_pwm`
+`mirte/get_pin_value`
+`mirte/set_pin_mode`
+`mirte/set_pin_value`
+`mirte_service_api/get_<topic_name>`
 
 
 ## Parameters
@@ -33,26 +33,26 @@ device/mirte/dev (string, default: "/dev/ttyUSB0")
     The linux device name of the board.
 
 #### Distance sensor
-distance/<name>_distance/dev (string, default: "mirte")
-distance/<name>_distance/frequency (int, default: 10)
+`distance/<name>_distance/dev` (string, default: "mirte")
+`distance/<name>_distance/frequency` (int, default: 10)
     The frequency to publish new sensor data
-distance/<name>_distance/pin (array)
+`distance/<name>_distance/pin` (array)
     The (arduino/stm32) pins it is connected to [trigger-pin, echo-pin] (eg [8. 13])
 
 #### Encoder sensor
 Note: the encoder sensor does not have a frequency since it uses the interrupt pins
-encoder/<name>_encoder/device (string, default: "mirte")
-encoder/<name>_encoder/pin (int)
-encoder/<name>_encoder/ticks_per_wheel (int, default: 20)
+`encoder/<name>_encoder/device` (string, default: "mirte")
+`encoder/<name>_encoder/pin` (int)
+`encoder/<name>_encoder/ticks_per_wheel` (int, default: 20)
 
 #### Intensity sensor
-intensity/<name>_intensity/device (string, default: "mirte")
-intensity/<name>_intensity/frequency (int, default: 10)
-intensity/<name>_intensity/pin (int)
+`intensity/<name>_intensity/device` (string, default: "mirte")
+`intensity/<name>_intensity/frequency` (int, default: 10)
+`intensity/<name>_intensity/pin` (int)
 
 #### Motor settings
-motor/<name>_motor/device (string, default: "mirte")
-motor/<name>_motor/pin (array)
+`motor/<name>_motor/device` (string, default: "mirte")
+`motor/<name>_motor/pin` (array)
      The (arduino/stm32) pins the motor (h-bridge) is connected to. When using 2 pins per motor it will assume MX1919 (both PWM signals). When using 3 pins it will assume L298N (1 PWM, 2 non-PWM)
 
 

--- a/mirte_control/mirte_base_control/include/my_robot_hw_interface.h
+++ b/mirte_control/mirte_base_control/include/my_robot_hw_interface.h
@@ -251,13 +251,13 @@ MyRobotHWInterface::MyRobotHWInterface()
           "start", &MyRobotHWInterface::start_callback, this)),
       stop_srv_(nh.advertiseService("stop", &MyRobotHWInterface::stop_callback,
                                     this)) {
-  private_nh.param<double>("mobile_base_controller/wheel_radius",
+  nh.param<double>("mobile_base_controller/wheel_radius",
                            _wheel_diameter, 0.06);
   _wheel_diameter *= 2; // convert from radius to diameter
-  private_nh.param<double>("mobile_base_controller/max_speed", _max_speed,
+  nh.param<double>("mobile_base_controller/max_speed", _max_speed,
                            2.0); // TODO: unused
-  private_nh.param<double>("mobile_base_controller/ticks", ticks, 40.0);
-  this->NUM_JOINTS = detect_joints(private_nh);
+  nh.param<double>("mobile_base_controller/ticks", ticks, 40.0);
+  this->NUM_JOINTS = detect_joints(nh);
   if (this->NUM_JOINTS > 2) {
     this->bidirectional = true;
   }
@@ -309,7 +309,7 @@ MyRobotHWInterface::MyRobotHWInterface()
   registerInterface(&jnt_state_interface);
   registerInterface(&jnt_vel_interface);
 
-  private_nh.param<bool>("mobile_base_controller/enable_pid",
+  nh.param<bool>("mobile_base_controller/enable_pid",
                            enablePID, false);
   enablePID = true;
   if(enablePID) {

--- a/mirte_control/mirte_base_control/include/my_robot_hw_interface.h
+++ b/mirte_control/mirte_base_control/include/my_robot_hw_interface.h
@@ -37,8 +37,8 @@
 #include <thread>
 #include <control_toolbox/pid.h>
 // const unsigned int NUM_JOINTS = 4;
-const auto service_format = "/mirte/set_%s_speed";
-const auto encoder_format = "/mirte/encoder/%s";
+const auto service_format = "mirte/set_%s_speed";
+const auto encoder_format = "mirte/encoder/%s";
 const auto max_speed = 100; // Quick fix hopefully for power dip.
 /// \brief Hardware interface for a robot
 class MyRobotHWInterface : public hardware_interface::RobotHW {
@@ -233,7 +233,7 @@ void MyRobotHWInterface::init_service_clients() {
 
 unsigned int detect_joints(ros::NodeHandle &nh) {
   std::string type;
-  nh.param<std::string>("/mobile_base_controller/type", type, "");
+  nh.param<std::string>("mobile_base_controller/type", type, "");
   if (type.rfind("mecanum", 0) == 0) { // starts with mecanum
     return 4;
   } else if (type.rfind("diff", 0) == 0) { // starts with diff
@@ -251,12 +251,12 @@ MyRobotHWInterface::MyRobotHWInterface()
           "start", &MyRobotHWInterface::start_callback, this)),
       stop_srv_(nh.advertiseService("stop", &MyRobotHWInterface::stop_callback,
                                     this)) {
-  private_nh.param<double>("/mobile_base_controller/wheel_radius",
+  private_nh.param<double>("mobile_base_controller/wheel_radius",
                            _wheel_diameter, 0.06);
   _wheel_diameter *= 2; // convert from radius to diameter
-  private_nh.param<double>("/mobile_base_controller/max_speed", _max_speed,
+  private_nh.param<double>("mobile_base_controller/max_speed", _max_speed,
                            2.0); // TODO: unused
-  private_nh.param<double>("/mobile_base_controller/ticks", ticks, 40.0);
+  private_nh.param<double>("mobile_base_controller/ticks", ticks, 40.0);
   this->NUM_JOINTS = detect_joints(private_nh);
   if (this->NUM_JOINTS > 2) {
     this->bidirectional = true;
@@ -309,13 +309,13 @@ MyRobotHWInterface::MyRobotHWInterface()
   registerInterface(&jnt_state_interface);
   registerInterface(&jnt_vel_interface);
 
-  private_nh.param<bool>("/mobile_base_controller/enable_pid",
+  private_nh.param<bool>("mobile_base_controller/enable_pid",
                            enablePID, false);
   enablePID = true;
   if(enablePID) {
     for(auto i = 0; i < NUM_JOINTS; i++) {
       auto pid = std::make_shared< control_toolbox::Pid>(1, 0, 0);
-      // pid->initParam((boost::format("/mobile_base_controller/%s")%this->joints[i]).str(), false);
+      // pid->initParam((boost::format("mobile_base_controller/%s")%this->joints[i]).str(), false);
       this->pids.push_back(pid);
 
     }

--- a/mirte_control/ros_control_boilerplate/rrbot_control/src/rrbot_hw_interface.cpp
+++ b/mirte_control/ros_control_boilerplate/rrbot_control/src/rrbot_hw_interface.cpp
@@ -90,13 +90,13 @@ RRBotHWInterface::RRBotHWInterface(ros::NodeHandle &nh, urdf::Model *urdf_model)
     : ros_control_boilerplate::GenericHWInterface(nh, urdf_model) {
   this->connectServices();
 
-  sub0 = nh.subscribe("/mirte/servos/servoRot/position", 1,
+  sub0 = nh.subscribe("mirte/servos/servoRot/position", 1,
                       rrbot_control::callbackJoint0);
-  sub1 = nh.subscribe("/mirte/servos/servoShoulder/position", 1,
+  sub1 = nh.subscribe("mirte/servos/servoShoulder/position", 1,
                       rrbot_control::callbackJoint1);
-  sub2 = nh.subscribe("/mirte/servos/servoElbow/position", 1,
+  sub2 = nh.subscribe("mirte/servos/servoElbow/position", 1,
                       rrbot_control::callbackJoint2);
-  sub3 = nh.subscribe("/mirte/servos/servoWrist/position", 1,
+  sub3 = nh.subscribe("mirte/servos/servoWrist/position", 1,
                       rrbot_control::callbackJoint3);
 
   ROS_INFO_NAMED("rrbot_hw_interface", "RRBotHWInterface Ready.");
@@ -105,20 +105,20 @@ RRBotHWInterface::RRBotHWInterface(ros::NodeHandle &nh, urdf::Model *urdf_model)
 void RRBotHWInterface::connectServices() {
   ROS_INFO_NAMED("rrbot_hw_interface", "Connecting to the services...");
 
-  ros::service::waitForService("/mirte/set_servoRot_servo_angle", -1);
-  ros::service::waitForService("/mirte/set_servoShoulder_servo_angle", -1);
-  ros::service::waitForService("/mirte/set_servoElbow_servo_angle", -1);
-  ros::service::waitForService("/mirte/set_servoWrist_servo_angle", -1);
+  ros::service::waitForService("mirte/set_servoRot_servo_angle", -1);
+  ros::service::waitForService("mirte/set_servoShoulder_servo_angle", -1);
+  ros::service::waitForService("mirte/set_servoElbow_servo_angle", -1);
+  ros::service::waitForService("mirte/set_servoWrist_servo_angle", -1);
   { // Only mutex when actually writing to class vars.
     const std::lock_guard<std::mutex> lock(this->service_clients_mutex);
     client0 = nh_.serviceClient<mirte_msgs::SetServoAngle>(
-        "/mirte/set_servoRot_servo_angle", true);
+        "mirte/set_servoRot_servo_angle", true);
     client1 = nh_.serviceClient<mirte_msgs::SetServoAngle>(
-        "/mirte/set_servoShoulder_servo_angle", true);
+        "mirte/set_servoShoulder_servo_angle", true);
     client2 = nh_.serviceClient<mirte_msgs::SetServoAngle>(
-        "/mirte/set_servoElbow_servo_angle", true);
+        "mirte/set_servoElbow_servo_angle", true);
     client3 = nh_.serviceClient<mirte_msgs::SetServoAngle>(
-        "/mirte/set_servoWrist_servo_angle", true);
+        "mirte/set_servoWrist_servo_angle", true);
   }
   ROS_INFO_NAMED("rrbot_hw_interface", "Connected to the services");
 }

--- a/mirte_telemetrix/scripts/ROS_telemetrix_aio_api.py
+++ b/mirte_telemetrix/scripts/ROS_telemetrix_aio_api.py
@@ -23,7 +23,7 @@ from modules import MPU9250
 
 
 # NOTE: This call was unused
-# devices = rospy.get_param("/mirte/device")
+# devices = rospy.get_param("mirte/device")
 
 
 current_soc = "???"  # TODO: change to something better, but for now we communicate SOC from the powerwatcher to the Oled using a global

--- a/mirte_telemetrix/scripts/modules/MPU9250.py
+++ b/mirte_telemetrix/scripts/modules/MPU9250.py
@@ -39,14 +39,14 @@ class MPU9250:
         except Exception as e:
             pass
         self.imu_publisher = rospy.Publisher(
-            f"/mirte/{self.name}/imu", Imu, queue_size=1
+            f"mirte/{self.name}/imu", Imu, queue_size=1
         )
         # self.i2c_port = 0
         # TODO: no support yet for other addresses than 0x68
         await self.board.sensors.add_mpu9250(self.i2c_port, self.callback)
 
         self.serv = rospy.Service(
-            f"/mirte/{self.name}/get_imu",
+            f"mirte/{self.name}/get_imu",
             GetIMU,
             self.get_imu_service,
         )

--- a/mirte_teleop/launch/teleop_holo_joy.launch
+++ b/mirte_teleop/launch/teleop_holo_joy.launch
@@ -14,6 +14,6 @@
           type="teleop_node" output="screen">
         <!-- <param name="scale_linear" value="2"/>
         <param name="scale_angular" value="2"/> -->
-        <remap from="/cmd_vel" to="/mobile_base_controller/cmd_vel"/>
+        <remap from="/cmd_vel" to="mobile_base_controller/cmd_vel"/>
     </node>
 </launch>

--- a/mirte_teleop/launch/teleop_joy.launch
+++ b/mirte_teleop/launch/teleop_joy.launch
@@ -9,6 +9,6 @@
           type="teleop_node" output="screen">
         <param name="scale_linear" value="0.03"/>
         <param name="scale_angular" value="-0.5"/>
-        <remap from="/cmd_vel" to="/mobile_base_controller/cmd_vel"/>
+        <remap from="/cmd_vel" to="mobile_base_controller/cmd_vel"/>
     </node>
 </launch>

--- a/mirte_teleop/launch/teleopkey.launch
+++ b/mirte_teleop/launch/teleopkey.launch
@@ -6,7 +6,7 @@
           type="teleop_twist_keyboard.py" output="screen">
         <param name="speed" value="2"/>
         <param name="turn" value="2"/>
-        <remap from="/cmd_vel" to="/mobile_base_controller/cmd_vel"/>
+        <remap from="/cmd_vel" to="mobile_base_controller/cmd_vel"/>
     </node>
 
 </launch>

--- a/mirte_teleop/scripts/joyArm.py
+++ b/mirte_teleop/scripts/joyArm.py
@@ -74,15 +74,15 @@ def talker():
     global set_rot, set_sh, set_el, set_gr
     rospy.init_node("arm_control", anonymous=True)
     rospy.Subscriber("/joy", Joy, callback_joy, queue_size=1)
-    rospy.Subscriber("/mirte/servos/servoRot/position", ServoPosition, cb_rot)
-    rospy.Subscriber("/mirte/servos/servoShoulder/position", ServoPosition, cb_sh)
-    rospy.Subscriber("/mirte/servos/servoElbow/position", ServoPosition, cb_el)
-    rospy.Subscriber("/mirte/servos/servoGripper/position", ServoPosition, cb_gr)
+    rospy.Subscriber("mirte/servos/servoRot/position", ServoPosition, cb_rot)
+    rospy.Subscriber("mirte/servos/servoShoulder/position", ServoPosition, cb_sh)
+    rospy.Subscriber("mirte/servos/servoElbow/position", ServoPosition, cb_el)
+    rospy.Subscriber("mirte/servos/servoGripper/position", ServoPosition, cb_gr)
 
-    set_rot = rospy.ServiceProxy("/mirte/set_servoRot_servo_angle", SetServoAngle)
-    set_sh = rospy.ServiceProxy("/mirte/set_servoShoulder_servo_angle", SetServoAngle)
-    set_el = rospy.ServiceProxy("/mirte/set_servoElbow_servo_angle", SetServoAngle)
-    set_gr = rospy.ServiceProxy("/mirte/set_servoGripper_servo_angle", SetServoAngle)
+    set_rot = rospy.ServiceProxy("mirte/set_servoRot_servo_angle", SetServoAngle)
+    set_sh = rospy.ServiceProxy("mirte/set_servoShoulder_servo_angle", SetServoAngle)
+    set_el = rospy.ServiceProxy("mirte/set_servoElbow_servo_angle", SetServoAngle)
+    set_gr = rospy.ServiceProxy("mirte/set_servoGripper_servo_angle", SetServoAngle)
 
     rate = rospy.Rate(10)  # 10hz
     while not rospy.is_shutdown():


### PR DESCRIPTION
The current implementation of the mirte-master packages gives errors when putting them in a name space.
This was the result of the hardcoded root topics and parameters.

This PR has changed that requirement for:
 - `mirte_telemetrix`
- `mirte_base_control`
- `ros_control_boilerplate`
- `mirte_teleop`

Not effected:
- `mirte_description` (No change required?)
- `mirte_moveit_config`

~(This code is untested since I don't have access to a mirte right now, will test tomorrow)~
Tested and functional