### PR TITLE
Register HiWonder Servos during runtime to prevent Servo num mismatches

### DIFF
--- a/mirte_telemetrix_cpp/src/modules/hiwonder/hiwonder_servo.cpp
+++ b/mirte_telemetrix_cpp/src/modules/hiwonder/hiwonder_servo.cpp
@@ -21,6 +21,12 @@ Hiwonder_servo::Hiwonder_servo(
                  "not found]",
                  this->servo_data->name.c_str(), this->servo_data->id);
 
+  if (this->bus_mod->register_servo_id(this->servo_data->id))
+    RCLCPP_ERROR(logger,
+                 "HiWonder Servo '%s' ID is out of range [Requesed ID %d, but "
+                 "range is 0-253]",
+                 this->servo_data->name.c_str(), this->servo_data->id);
+
   auto range = this->bus_mod->get_range(servo_data->id);
   assert(range.has_value());
   auto [lower, upper] = range.value();

--- a/mirte_telemetrix_cpp/src/modules/hiwonder_module.cpp
+++ b/mirte_telemetrix_cpp/src/modules/hiwonder_module.cpp
@@ -28,8 +28,9 @@ HiWonderBus_module::HiWonderBus_module(
 
   // Create a list of ID's
   std::vector<uint8_t> servo_ids;
-  for (auto servo : this->data.servos)
-    servo_ids.push_back(servo->id);
+  // Don't pre-add ids since it can cause errors on missing servos
+  // for (auto servo : this->data.servos)
+  //   servo_ids.push_back(servo->id);
 
   this->bus = std::make_shared<tmx_cpp::HiwonderServo_module>(
       this->data.uart_port, this->data.rx_pin, this->data.tx_pin, servo_ids,


### PR DESCRIPTION
Uses enabled functionality to add servos at runtime to prevent `servo_num` mismatches with the pico.
It requires: ArendJan/tmx-cpp#5 and ArendJan/Telemetrix4RpiPico#6

Note: THIS CODE IS UNTESTED ON HARDWARE, DUE TO LACK OF HARDWARE.
