### PR TITLE
Add mpu6050+bno055 imus & fix pca9685 servo control for bep

### DIFF
--- a/.github/workflows/cpp-check.yml
+++ b/.github/workflows/cpp-check.yml
@@ -15,3 +15,16 @@ jobs:
         extensions: 'c,h,cpp,hpp'
         clangFormatVersion: 18
         style: llvm
+  cmake-format-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.9'
+    - run: |
+        python -m pip install --upgrade pip
+        pip3 install cmake-format
+        cmake-format -i mirte_telemetrix_cpp/CMakeLists.txt       
+        git --no-pager diff --exit-code -- mirte_telemetrix_cpp/CMakeLists.txt

--- a/mirte_msgs/CMakeLists.txt
+++ b/mirte_msgs/CMakeLists.txt
@@ -61,6 +61,7 @@ set(srv_files
     "srv/SetAngleMultiple.srv"
     "srv/SetServoVoltageRange.srv"
     "srv/SetServoUS.srv"
+    "srv/SetServoPWM.srv"
     )
 
 rosidl_generate_interfaces(

--- a/mirte_msgs/CMakeLists.txt
+++ b/mirte_msgs/CMakeLists.txt
@@ -60,6 +60,7 @@ set(srv_files
     "srv/SetNeopixelSingle.srv"
     "srv/SetAngleMultiple.srv"
     "srv/SetServoVoltageRange.srv"
+    "srv/SetServoUS.srv"
     )
 
 rosidl_generate_interfaces(

--- a/mirte_msgs/srv/SetServoPWM.srv
+++ b/mirte_msgs/srv/SetServoPWM.srv
@@ -1,0 +1,5 @@
+float64 percentage
+---
+# Set pca servo pin
+bool status    # indicate successful run
+string message # informational for error messages

--- a/mirte_msgs/srv/SetServoUS.srv
+++ b/mirte_msgs/srv/SetServoUS.srv
@@ -1,0 +1,4 @@
+uint16 time_us   # servo time in microseconds, typically between 1000 and 2000
+---
+bool status    # indicate successful run
+string message # informational for error messages

--- a/mirte_telemetrix_cpp/CMakeLists.txt
+++ b/mirte_telemetrix_cpp/CMakeLists.txt
@@ -60,7 +60,7 @@ include_directories(
   include/ libs/tmx-cpp/include/ libs/tmx-cpp/libs/async_serial/include/
   ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 
- set(config_files ina226 pca pca_motor hiwonder hiwonder_servo mpu9250 bno055 adxl345 as5600 as5600_sensor neopixel mpu6050 telemetrix)
+ set(config_files ina226 pca pca_motor pca_servo hiwonder hiwonder_servo mpu9250 bno055 adxl345 as5600 as5600_sensor neopixel mpu6050 telemetrix)
 set(param_libs "")
 foreach (config_file IN LISTS config_files)
   generate_parameter_library(

--- a/mirte_telemetrix_cpp/CMakeLists.txt
+++ b/mirte_telemetrix_cpp/CMakeLists.txt
@@ -60,7 +60,7 @@ include_directories(
   include/ libs/tmx-cpp/include/ libs/tmx-cpp/libs/async_serial/include/
   ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 
- set(config_files ina226 pca pca_motor hiwonder hiwonder_servo mpu9250 adxl345 as5600 as5600_sensor neopixel telemetrix)
+ set(config_files ina226 pca pca_motor hiwonder hiwonder_servo mpu9250 adxl345 as5600 as5600_sensor neopixel mpu6050 telemetrix)
 set(param_libs "")
 foreach (config_file IN LISTS config_files)
   generate_parameter_library(
@@ -128,6 +128,7 @@ add_executable(
   src/parsers/modules/pca/pca_servo_data.cpp
   src/parsers/modules/ssd1306_data.cpp
   src/parsers/modules/mpu9250_data.cpp
+  src/parsers/modules/mpu6050_data.cpp
   src/parsers/modules/veml6040_data.cpp
   src/sensors/base_sensor.cpp
   src/sensors/encoder_monitor.cpp
@@ -145,7 +146,9 @@ add_executable(
   src/modules/pca/pca_servo.cpp
   src/modules/ssd1306_module.cpp
   src/modules/as5600_module.cpp
-  src/modules/veml6040_module.cpp)
+  src/modules/veml6040_module.cpp
+  src/modules/mpu6050_module.cpp
+  )
 ament_target_dependencies(
   ${PROJECT_NAME}_node
   std_msgs

--- a/mirte_telemetrix_cpp/CMakeLists.txt
+++ b/mirte_telemetrix_cpp/CMakeLists.txt
@@ -60,7 +60,7 @@ include_directories(
   include/ libs/tmx-cpp/include/ libs/tmx-cpp/libs/async_serial/include/
   ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 
- set(config_files ina226 pca pca_motor hiwonder hiwonder_servo mpu9250 adxl345 as5600 as5600_sensor neopixel mpu6050 telemetrix)
+ set(config_files ina226 pca pca_motor hiwonder hiwonder_servo mpu9250 bno055 adxl345 as5600 as5600_sensor neopixel mpu6050 telemetrix)
 set(param_libs "")
 foreach (config_file IN LISTS config_files)
   generate_parameter_library(
@@ -130,6 +130,7 @@ add_executable(
   src/parsers/modules/mpu9250_data.cpp
   src/parsers/modules/mpu6050_data.cpp
   src/parsers/modules/veml6040_data.cpp
+  src/parsers/modules/bno055_data.cpp
   src/sensors/base_sensor.cpp
   src/sensors/encoder_monitor.cpp
   src/sensors/intensity_monitor.cpp
@@ -148,6 +149,8 @@ add_executable(
   src/modules/as5600_module.cpp
   src/modules/veml6040_module.cpp
   src/modules/mpu6050_module.cpp
+  src/modules/bno055_module.cpp
+
   )
 ament_target_dependencies(
   ${PROJECT_NAME}_node
@@ -163,7 +166,7 @@ ament_target_dependencies(
   # system_lib
 )
 
-add_executable(${PROJECT_NAME}_test src/test.cpp src/parsers/parsers.cpp)
+add_executable(${PROJECT_NAME}_test src/test.cpp src/parsers/parsers.cpp libs/tmx-cpp/src/serialization.cpp)
 ament_target_dependencies(
   ${PROJECT_NAME}_test
   rclcpp

--- a/mirte_telemetrix_cpp/CMakeLists.txt
+++ b/mirte_telemetrix_cpp/CMakeLists.txt
@@ -210,6 +210,8 @@ if(0) # extra strict errors
             -Wextra
             -Wpedantic
             -Wconversion
+            -Wno-ignored-qualifiers
+            -Wno-unused-command-line-argument
             -Wno-sign-conversion
             -Wdouble-promotion
             -Wno-unused-parameter

--- a/mirte_telemetrix_cpp/CMakeLists.txt
+++ b/mirte_telemetrix_cpp/CMakeLists.txt
@@ -18,7 +18,8 @@ if(HAVE_GPIOD_HPP)
   add_compile_options(-lgpiodcxx)
 endif()
 
-# if x86, dont shutdown the robot, just print a message. This is for testing on x86 machines without a shutdown relay.
+# if x86, dont shutdown the robot, just print a message. This is for testing on
+# x86 machines without a shutdown relay.
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64|i386|i686")
   add_compile_definitions(MIRTE_TESTING_ON_X86)
 endif()
@@ -55,25 +56,36 @@ find_package(Boost REQUIRED COMPONENTS system thread)
 
 # Specify additional locations of header files Your package locations should be
 # listed before other locations
-add_subdirectory(libs/tmx-cpp EXCLUDE_FROM_ALL) 
+add_subdirectory(libs/tmx-cpp EXCLUDE_FROM_ALL)
 include_directories(
   include/ libs/tmx-cpp/include/ libs/tmx-cpp/libs/async_serial/include/
   ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 
- set(config_files ina226 pca pca_motor pca_servo hiwonder hiwonder_servo mpu9250 bno055 adxl345 as5600 as5600_sensor neopixel mpu6050 telemetrix)
+set(config_files
+    ina226
+    pca
+    pca_motor
+    pca_servo
+    hiwonder
+    hiwonder_servo
+    mpu9250
+    bno055
+    adxl345
+    as5600
+    as5600_sensor
+    neopixel
+    mpu6050
+    telemetrix)
 set(param_libs "")
-foreach (config_file IN LISTS config_files)
+foreach(config_file IN LISTS config_files)
   generate_parameter_library(
     ${config_file}_parameters # cmake target name for the parameter library
     src/parsers/configs/${config_file}_parameters.yaml # path to input yaml file
   )
   list(APPEND param_libs ${config_file}_parameters)
 endforeach()
-# generate_parameter_library(
-#   telemetrix_parameters # cmake target name for the parameter library
-#   src/telemetrix_parameters.yaml # path to input yaml file
-# )
-
+# generate_parameter_library( telemetrix_parameters # cmake target name for the
+# parameter library src/telemetrix_parameters.yaml # path to input yaml file )
 
 # include(CheckIPOSupported) check_ipo_supported(RESULT supported OUTPUT error)
 
@@ -149,9 +161,7 @@ add_executable(
   src/modules/as5600_module.cpp
   src/modules/veml6040_module.cpp
   src/modules/mpu6050_module.cpp
-  src/modules/bno055_module.cpp
-
-  )
+  src/modules/bno055_module.cpp)
 ament_target_dependencies(
   ${PROJECT_NAME}_node
   std_msgs
@@ -166,15 +176,10 @@ ament_target_dependencies(
   # system_lib
 )
 
-add_executable(${PROJECT_NAME}_test src/test.cpp src/parsers/parsers.cpp libs/tmx-cpp/src/serialization.cpp)
-ament_target_dependencies(
-  ${PROJECT_NAME}_test
-  rclcpp
-  rcpputils
-  mirte_msgs
-  backward_ros
-)
-
+add_executable(${PROJECT_NAME}_test src/test.cpp src/parsers/parsers.cpp
+                                    libs/tmx-cpp/src/serialization.cpp)
+ament_target_dependencies(${PROJECT_NAME}_test rclcpp rcpputils mirte_msgs
+                          backward_ros)
 
 if(0) # extra strict errors
   target_compile_options(
@@ -196,8 +201,14 @@ if(0) # extra strict errors
 endif()
 
 # Specify libraries to link a library or executable target against
-target_link_libraries(${PROJECT_NAME}_node Boost::system Boost::thread tmx_cpp ${param_libs}
-                      ${MIRTE_EXTRA_LIBS} ${OpenCV_LIBS})
+target_link_libraries(
+  ${PROJECT_NAME}_node
+  Boost::system
+  Boost::thread
+  tmx_cpp
+  ${param_libs}
+  ${MIRTE_EXTRA_LIBS}
+  ${OpenCV_LIBS})
 
 target_link_libraries(${PROJECT_NAME}_test ${param_libs})
 # if(supported) if(CMAKE_BUILD_TYPE STREQUAL "Release") message(STATUS "IPO LTO
@@ -210,9 +221,10 @@ install(
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin)
-install(TARGETS ${PROJECT_NAME}_node ${PROJECT_NAME}_test DESTINATION lib/${PROJECT_NAME})
+install(TARGETS ${PROJECT_NAME}_node ${PROJECT_NAME}_test
+        DESTINATION lib/${PROJECT_NAME})
 install(TARGETS ${PROJECT_NAME}_node ${PROJECT_NAME}_test ${param_libs}
-  EXPORT ${PROJECT_NAME}Targets)
+        EXPORT ${PROJECT_NAME}Targets)
 ament_export_targets(${PROJECT_NAME}Targets HAS_LIBRARY_TARGET)
 
 # EXPORTS ament_export_targets( ${PROJECT_NAME}_node HAS_LIBRARY_TARGET)

--- a/mirte_telemetrix_cpp/README.md
+++ b/mirte_telemetrix_cpp/README.md
@@ -10,7 +10,7 @@
 | **Sensors**            |                           |                      |                                                                                       |
 | Sonar                  | ✅                        | ✅                   |                                                                                       |
 | intensity              | ✅                        | ✅                   |                                                                                       |
-| encoders               | ✅                        | ✅ ?                 |                                                                                       |
+| encoders               | ✅                        | ✅                   |                                                                                       |
 | get pin service        | ✅                        | ✅                   | Reading output pins results in undefined behavior (Tested digital read a digital out) |
 | **Actuators**          |                           |                      |                                                                                       |
 | oled                   | ✅                        | 🔷                   | OLED is now a Module. (Maybe the parsing can be improved to be more like old style)   |
@@ -19,11 +19,11 @@
 | motors                 | ✅                        | ❓                   | L9110S (PP) & L298N (DDP) work                                                        |
 | set pin service        | ✅                        | ✅                   | Digital not tested as much                                                            |
 | **Mirte-master parts** |                           |                      |                                                                                       |
-| hiwonder servo         | ✅                        | ✅ ?Needs more testing|                                                                                      |
+| hiwonder servo         | ✅                        | ✅                   |                                                                                      |
 | pca9685 pwm            | ✅                        | ✅                   |                                                                                       |
 | ina226                 | ✅                        | ✅                   | shutdown relay not implemented as hw is not working.                                  |
-| imu                    | ✅                        | ✅                   |                                                                                       |
-| ledstrip               | ✅                        | ❌                   |                                                                                       |
+| imu                    | ✅                        | ✅                   | mpu9250                                                                               |
+| ledstrip               | ✅                        | ✅                   |                                                                                       |
 | oled module            | ✅                        | ✅                   |                                                                                       |
 
 

--- a/mirte_telemetrix_cpp/include/mirte_telemetrix_cpp/actuators/neopixel.hpp
+++ b/mirte_telemetrix_cpp/include/mirte_telemetrix_cpp/actuators/neopixel.hpp
@@ -20,7 +20,7 @@ public:
                std::shared_ptr<Mirte_Board> board, std::string name,
                std::map<std::string, rclcpp::ParameterValue> parameters,
                std::set<std::string> &unused_keys);
-  NeopixelData() = default;
+  NeopixelData() = delete;
   static std::string get_device_class() { return "neopixel"; }
   int num_leds;
   uint8_t data_pin;

--- a/mirte_telemetrix_cpp/include/mirte_telemetrix_cpp/actuators/servo/servo.hpp
+++ b/mirte_telemetrix_cpp/include/mirte_telemetrix_cpp/actuators/servo/servo.hpp
@@ -9,7 +9,7 @@ public:
   ~Servo();
 
   virtual bool set_angle_us(uint16_t duty_cycle) override;
-
+  virtual bool set_percentage(float percentage) override;
   static std::vector<std::shared_ptr<Servo>>
   get_servos(NodeData node_data, std::shared_ptr<Parser> parser);
 };

--- a/mirte_telemetrix_cpp/include/mirte_telemetrix_cpp/actuators/servo_base.hpp
+++ b/mirte_telemetrix_cpp/include/mirte_telemetrix_cpp/actuators/servo_base.hpp
@@ -9,7 +9,9 @@
 #include <mirte_telemetrix_cpp/parsers/actuators/servo_data.hpp>
 
 #include <mirte_msgs/srv/get_servo_range.hpp>
+#include <mirte_msgs/srv/set_motor_speed.hpp>
 #include <mirte_msgs/srv/set_servo_angle.hpp>
+#include <mirte_msgs/srv/set_servo_pwm.hpp>
 #include <mirte_msgs/srv/set_servo_us.hpp>
 
 class ServoBase : public TelemetrixDevice {
@@ -19,9 +21,10 @@ public:
                 rclcpp::CallbackGroupType::Reentrant);
 
   virtual bool set_angle_us(uint16_t duty_cycle) = 0;
+  virtual bool set_percentage(float percentage) = 0;
 
-  // TODO: Still storing this specific data, I'm unsure if that is good or bad.
   ServoData data;
+  void set_speed(float speed);
 
 private:
   // Service: servo/NAME/set_angle
@@ -29,6 +32,8 @@ private:
   // Service: servo/NAME/get_range
   rclcpp::Service<mirte_msgs::srv::GetServoRange>::SharedPtr get_range_service;
   rclcpp::Service<mirte_msgs::srv::SetServoUS>::SharedPtr set_us_service;
+
+  void setup_servo();
 
   void set_angle_service_callback(
       const mirte_msgs::srv::SetServoAngle::Request::ConstSharedPtr req,
@@ -41,4 +46,17 @@ private:
   void set_us_service_callback(
       const mirte_msgs::srv::SetServoUS::Request::ConstSharedPtr req,
       mirte_msgs::srv::SetServoUS::Response::SharedPtr res);
+
+  void setup_motor();
+  rclcpp::Service<mirte_msgs::srv::SetMotorSpeed>::SharedPtr set_speed_service;
+  void set_speed_service_callback(
+      const mirte_msgs::srv::SetMotorSpeed::Request::ConstSharedPtr req,
+      mirte_msgs::srv::SetMotorSpeed::Response::SharedPtr res);
+
+  void setup_pwm(); // only really for pca servo, but can be used for regular
+                    // servo as well.
+  void set_pwm_service_callback(
+      const mirte_msgs::srv::SetServoPWM::Request::ConstSharedPtr req,
+      mirte_msgs::srv::SetServoPWM::Response::SharedPtr res);
+  rclcpp::Service<mirte_msgs::srv::SetServoPWM>::SharedPtr set_pwm_service;
 };

--- a/mirte_telemetrix_cpp/include/mirte_telemetrix_cpp/actuators/servo_base.hpp
+++ b/mirte_telemetrix_cpp/include/mirte_telemetrix_cpp/actuators/servo_base.hpp
@@ -10,6 +10,7 @@
 
 #include <mirte_msgs/srv/get_servo_range.hpp>
 #include <mirte_msgs/srv/set_servo_angle.hpp>
+#include <mirte_msgs/srv/set_servo_us.hpp>
 
 class ServoBase : public TelemetrixDevice {
 public:
@@ -27,6 +28,7 @@ private:
   rclcpp::Service<mirte_msgs::srv::SetServoAngle>::SharedPtr set_angle_service;
   // Service: servo/NAME/get_range
   rclcpp::Service<mirte_msgs::srv::GetServoRange>::SharedPtr get_range_service;
+  rclcpp::Service<mirte_msgs::srv::SetServoUS>::SharedPtr set_us_service;
 
   void set_angle_service_callback(
       const mirte_msgs::srv::SetServoAngle::Request::ConstSharedPtr req,
@@ -35,4 +37,8 @@ private:
   void get_range_service_callback(
       const mirte_msgs::srv::GetServoRange::Request::ConstSharedPtr req,
       mirte_msgs::srv::GetServoRange::Response::SharedPtr res);
+
+  void set_us_service_callback(
+      const mirte_msgs::srv::SetServoUS::Request::ConstSharedPtr req,
+      mirte_msgs::srv::SetServoUS::Response::SharedPtr res);
 };

--- a/mirte_telemetrix_cpp/include/mirte_telemetrix_cpp/modules/bno055_module.hpp
+++ b/mirte_telemetrix_cpp/include/mirte_telemetrix_cpp/modules/bno055_module.hpp
@@ -1,0 +1,46 @@
+#pragma once
+#include <array>
+#include <memory>
+#include <mutex>
+
+#include <tmx_cpp/sensors/BNO055.hpp>
+
+#include <mirte_telemetrix_cpp/modules/base_module.hpp>
+
+#include <mirte_telemetrix_cpp/parsers/modules/bno055_data.hpp>
+
+#include <mirte_msgs/srv/get_imu.hpp>
+#include <sensor_msgs/msg/imu.hpp>
+
+class BNO055_sensor : public Mirte_module {
+public:
+  BNO055_sensor(NodeData node_data, BNO055Data imu_data,
+                std::shared_ptr<tmx_cpp::Sensors> sensors);
+
+  BNO055Data data;
+  std::shared_ptr<tmx_cpp::BNO055_module> BNO055;
+
+  virtual void update() override;
+  void data_callback(const tmx_cpp::BNO055_MOD_data &data);
+  // std::array<float, 3> acceleration,
+  //                  std::array<float, 3> gyro,
+  //                  std::array<float, 3> magnetic_field,
+  //                  std::array<float, 4> quaternion);
+
+  static std::vector<std::shared_ptr<BNO055_sensor>>
+  get_bno_modules(NodeData node_data, std::shared_ptr<Parser> parser,
+                  std::shared_ptr<tmx_cpp::Sensors> sensors);
+
+private:
+  std::mutex msg_mutex;
+  sensor_msgs::msg::Imu msg;
+
+  // Publisher: imu/NAME/data
+  rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr imu_pub;
+  // Service: imu/NAME/get_data
+  rclcpp::Service<mirte_msgs::srv::GetImu>::SharedPtr imu_service;
+
+  void get_imu_service_callback(
+      const mirte_msgs::srv::GetImu::Request::ConstSharedPtr req,
+      mirte_msgs::srv::GetImu::Response::SharedPtr res);
+};

--- a/mirte_telemetrix_cpp/include/mirte_telemetrix_cpp/modules/mpu6050_module.hpp
+++ b/mirte_telemetrix_cpp/include/mirte_telemetrix_cpp/modules/mpu6050_module.hpp
@@ -1,0 +1,43 @@
+#pragma once
+#include <array>
+#include <memory>
+#include <mutex>
+
+#include <tmx_cpp/sensors/MPU6050.hpp>
+
+#include <mirte_telemetrix_cpp/modules/base_module.hpp>
+
+#include <mirte_telemetrix_cpp/parsers/modules/mpu6050_data.hpp>
+
+#include <mirte_msgs/srv/get_imu.hpp>
+#include <sensor_msgs/msg/imu.hpp>
+
+class MPU6050_sensor : public Mirte_module {
+public:
+  MPU6050_sensor(NodeData node_data, MPU6050Data imu_data,
+                 std::shared_ptr<tmx_cpp::Sensors> sensors);
+
+  MPU6050Data data;
+  std::shared_ptr<tmx_cpp::MPU6050_module> mpu6050;
+
+  virtual void update() override;
+  void data_callback(std::array<float, 3> acceleration,
+                     std::array<float, 3> gyro, float temperature);
+
+  static std::vector<std::shared_ptr<MPU6050_sensor>>
+  get_mpu_modules(NodeData node_data, std::shared_ptr<Parser> parser,
+                  std::shared_ptr<tmx_cpp::Sensors> sensors);
+
+private:
+  std::mutex msg_mutex;
+  sensor_msgs::msg::Imu msg;
+
+  // Publisher: imu/NAME/data
+  rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr imu_pub;
+  // Service: imu/NAME/get_data
+  rclcpp::Service<mirte_msgs::srv::GetImu>::SharedPtr imu_service;
+
+  void get_imu_service_callback(
+      const mirte_msgs::srv::GetImu::Request::ConstSharedPtr req,
+      mirte_msgs::srv::GetImu::Response::SharedPtr res);
+};

--- a/mirte_telemetrix_cpp/include/mirte_telemetrix_cpp/modules/pca/pca_servo.hpp
+++ b/mirte_telemetrix_cpp/include/mirte_telemetrix_cpp/modules/pca/pca_servo.hpp
@@ -19,4 +19,5 @@ public:
   std::shared_ptr<tmx_cpp::PCA9685_module> pca9685_mod;
 
   virtual bool set_angle_us(uint16_t duty_cycle) override;
+  virtual bool set_percentage(float percentage) override;
 };

--- a/mirte_telemetrix_cpp/include/mirte_telemetrix_cpp/parsers/actuators/servo_data.hpp
+++ b/mirte_telemetrix_cpp/include/mirte_telemetrix_cpp/parsers/actuators/servo_data.hpp
@@ -10,14 +10,20 @@ public:
   // Min/Max angle in degrees
   float min_angle = 0;
   float max_angle = 180;
-
+  bool invert = false;
+  std::string pin_mode = "servo"; // or "motor" or "pwm"
+  std::string frame_id = "";
+  float min_speed = -100; // Only used when pin_mode is motor
+  float max_speed = 100;  // Only used when pin_mode is motor
   ServoData(std::shared_ptr<Parser> parser, std::shared_ptr<Mirte_Board> board,
             std::string name,
             std::map<std::string, rclcpp::ParameterValue> parameters,
             std::set<std::string> &unused_keys);
 
   ServoData(pin_t pin, int min_pulse, int max_pulse, float min_angle,
-            float max_angle, std::string name, std::string frame_id = "");
+            float max_angle, std::string name, std::string frame_id = "",
+            bool invert = false, std::string pin_mode = "servo",
+            float min_speed = -100, float max_speed = 100);
 
   bool check();
   using DeviceData::check;

--- a/mirte_telemetrix_cpp/include/mirte_telemetrix_cpp/parsers/modules/bno055_data.hpp
+++ b/mirte_telemetrix_cpp/include/mirte_telemetrix_cpp/parsers/modules/bno055_data.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <mirte_telemetrix_cpp/parsers/modules/i2c_module_data.hpp>
+
+class BNO055Data : public I2CModuleData {
+public:
+  BNO055Data(std::shared_ptr<Parser> parser, std::shared_ptr<Mirte_Board> board,
+             std::string name,
+             std::map<std::string, rclcpp::ParameterValue> parameters,
+             std::set<std::string> &unused_keys);
+
+  bool check() override;
+  using I2CModuleData::check;
+
+  static std::string get_module_type() { return "BNO055"; };
+
+  // Required to change the default standard frame_id as specified in REP0145
+  static std::map<std::string, rclcpp::ParameterValue> insert_default_frame_id(
+      std::map<std::string, rclcpp::ParameterValue> parameters);
+  static std::set<std::string> &
+  insert_default_frame_id(std::set<std::string> &unused_keys);
+};

--- a/mirte_telemetrix_cpp/include/mirte_telemetrix_cpp/parsers/modules/mpu6050_data.hpp
+++ b/mirte_telemetrix_cpp/include/mirte_telemetrix_cpp/parsers/modules/mpu6050_data.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <mirte_telemetrix_cpp/parsers/modules/i2c_module_data.hpp>
+
+class MPU6050Data : public I2CModuleData {
+public:
+  MPU6050Data(std::shared_ptr<Parser> parser,
+              std::shared_ptr<Mirte_Board> board, std::string name,
+              std::map<std::string, rclcpp::ParameterValue> parameters,
+              std::set<std::string> &unused_keys);
+
+  bool check() override;
+  using I2CModuleData::check;
+
+  static std::string get_module_type() { return "mpu6050"; };
+
+  // Required to change the default standard frame_id as specified in REP0145
+  static std::map<std::string, rclcpp::ParameterValue> insert_default_frame_id(
+      std::map<std::string, rclcpp::ParameterValue> parameters);
+  static std::set<std::string> &
+  insert_default_frame_id(std::set<std::string> &unused_keys);
+};

--- a/mirte_telemetrix_cpp/include/mirte_telemetrix_cpp/parsers/modules/pca/pca_servo_data.hpp
+++ b/mirte_telemetrix_cpp/include/mirte_telemetrix_cpp/parsers/modules/pca/pca_servo_data.hpp
@@ -15,15 +15,25 @@ public:
   // Min/Max angle in degrees
   float min_angle = 0;
   float max_angle = 180;
+  bool invert = false;
+  std::string pin_mode = "servo"; // or "motor" or "pwm"
+
+  float min_speed = -100; // Only used when pin_mode is motor
+  float max_speed = 100;  // Only used when pin_mode is motor
 
   PCA_Servo_data(std::string name, pin_t pin, int min_pulse, int max_pulse,
-                 int min_angle, int max_angle) {
+                 int min_angle, int max_angle, bool invert,
+                 std::string pin_mode, float min_speed, float max_speed) {
     this->name = name;
     this->pin = pin;
     this->min_pulse = min_pulse;
     this->max_pulse = max_pulse;
     this->min_angle = min_angle;
     this->max_angle = max_angle;
+    this->invert = invert;
+    this->pin_mode = pin_mode;
+    this->min_speed = min_speed;
+    this->max_speed = max_speed;
   }
   PCA_Servo_data() {}
   static std::vector<std::shared_ptr<PCA_Servo_data>> parse_pca_servo_data(

--- a/mirte_telemetrix_cpp/src/actuators/servo/servo.cpp
+++ b/mirte_telemetrix_cpp/src/actuators/servo/servo.cpp
@@ -17,7 +17,13 @@ Servo::get_servos(NodeData node_data, std::shared_ptr<Parser> parser) {
         parameters["pins.pin"] = rclcpp::ParameterValue(map_servo.pins.pin);
         parameters["min_pulse"] = rclcpp::ParameterValue(map_servo.min_pulse);
         parameters["max_pulse"] = rclcpp::ParameterValue(map_servo.max_pulse);
+        parameters["min_angle"] = rclcpp::ParameterValue(map_servo.min_angle);
+        parameters["max_angle"] = rclcpp::ParameterValue(map_servo.max_angle);
+        parameters["invert"] = rclcpp::ParameterValue(map_servo.invert);
+        parameters["pin_mode"] = rclcpp::ParameterValue(map_servo.pin_mode);
         // parameters["frame_id"] = rclcpp::ParameterValue(map_servo.frame_id);
+        parameters["min_speed"] = rclcpp::ParameterValue(map_servo.min_speed);
+        parameters["max_speed"] = rclcpp::ParameterValue(map_servo.max_speed);
         std::set<std::string> unused_keys = get_keys(parameters);
         return ServoData(parser, node_data.board, name, parameters,
                          unused_keys);
@@ -39,5 +45,10 @@ Servo::~Servo() { tmx->detach_servo(data.pin); }
 bool Servo::set_angle_us(uint16_t duty_cycle) {
   tmx->write_servo(data.pin, std::clamp(duty_cycle, (uint16_t)data.min_pulse,
                                         (uint16_t)data.max_pulse));
+  return true;
+}
+bool Servo::set_percentage(float percentage) {
+  percentage = std::clamp(percentage, 0.0f, 100.0f);
+  tmx->pwmWrite(data.pin, percentage / 100.0f * tmx->board_features.pwm_max);
   return true;
 }

--- a/mirte_telemetrix_cpp/src/actuators/servo_base.cpp
+++ b/mirte_telemetrix_cpp/src/actuators/servo_base.cpp
@@ -11,7 +11,7 @@
 #include <mirte_telemetrix_cpp/actuators/servo_base.hpp>
 
 #include <mirte_msgs/srv/set_servo_angle.hpp>
-
+#include <mirte_msgs/srv/set_servo_pwm.hpp>
 /* The Servo callback group can be reentrant (Parrallel), since the second
  * callback does not influence the hardware. */
 ServoBase::ServoBase(NodeData node_data, std::vector<pin_t> pins,
@@ -20,6 +20,26 @@ ServoBase::ServoBase(NodeData node_data, std::vector<pin_t> pins,
     : TelemetrixDevice(node_data, pins, (DeviceData)servo_data,
                        callback_group_type),
       data(servo_data) {
+  if (data.pin_mode == "motor") {
+    this->setup_motor();
+  } else if (data.pin_mode == "pwm") {
+    this->setup_pwm();
+  } else {
+    this->setup_servo();
+  }
+
+  // make this service always available
+  this->set_us_service = nh->create_service<mirte_msgs::srv::SetServoUS>(
+      "servo/" + name + "/_set_us",
+      std::bind(&ServoBase::set_us_service_callback, this,
+                std::placeholders::_1, std::placeholders::_2),
+      rclcpp::ServicesQoS().get_rmw_qos_profile(), this->callback_group);
+}
+
+/**********************
+// SERVO MODE
+*********************/
+void ServoBase::setup_servo() {
   this->set_angle_service = nh->create_service<mirte_msgs::srv::SetServoAngle>(
       "servo/" + name + "/set_angle",
       std::bind(&ServoBase::set_angle_service_callback, this,
@@ -31,13 +51,11 @@ ServoBase::ServoBase(NodeData node_data, std::vector<pin_t> pins,
       std::bind(&ServoBase::get_range_service_callback, this,
                 std::placeholders::_1, std::placeholders::_2),
       rclcpp::ServicesQoS().get_rmw_qos_profile(), this->callback_group);
-  this->set_us_service = nh->create_service<mirte_msgs::srv::SetServoUS>(
-      "servo/" + name + "/_set_us",
-      std::bind(&ServoBase::set_us_service_callback, this,
-                std::placeholders::_1, std::placeholders::_2),
-      rclcpp::ServicesQoS().get_rmw_qos_profile(), this->callback_group);
 }
 
+float map(float x, float in_min, float in_max, float out_min, float out_max) {
+  return (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min;
+}
 void ServoBase::set_angle_service_callback(
     mirte_msgs::srv::SetServoAngle::Request::ConstSharedPtr req,
     mirte_msgs::srv::SetServoAngle::Response::SharedPtr res) {
@@ -58,9 +76,13 @@ void ServoBase::set_angle_service_callback(
     return;
   }
 
-  float fraction = (angle - data.min_angle) / (data.max_angle - data.min_angle);
+  float fraction = map(angle, data.min_angle, data.max_angle, 0.0, 100.0);
+  if (data.invert) {
+    fraction = 100.0 - fraction;
+  }
+
   uint16_t duty_cycle =
-      (uint16_t)(fraction * (data.max_pulse - data.min_pulse)) + data.min_pulse;
+      (uint16_t)(map(fraction, 0.0, 100.0, data.min_pulse, data.max_pulse));
   RCLCPP_WARN(logger, "Setting servo %s to angle %.3f degrees (duty cycle: %u)",
               name.c_str(), angle, duty_cycle);
   res->status = set_angle_us(duty_cycle);
@@ -92,4 +114,62 @@ void ServoBase::set_us_service_callback(
   RCLCPP_WARN(logger, "Setting servo %s to %u microseconds pulse width",
               name.c_str(), time_us);
   res->status = set_angle_us(time_us);
+}
+
+/**********************
+// MOTOR MODE
+*********************/
+void ServoBase::setup_motor() {
+  this->set_speed_service = nh->create_service<mirte_msgs::srv::SetMotorSpeed>(
+      "servo/" + name + "/set_speed",
+      std::bind(&ServoBase::set_speed_service_callback, this,
+                std::placeholders::_1, std::placeholders::_2),
+      rclcpp::ServicesQoS().get_rmw_qos_profile(), this->callback_group);
+}
+
+void ServoBase::set_speed_service_callback(
+    const mirte_msgs::srv::SetMotorSpeed::Request::ConstSharedPtr req,
+    mirte_msgs::srv::SetMotorSpeed::Response::SharedPtr res) {
+  float speed = req->speed;
+  RCLCPP_WARN(logger, "Setting motor %s to speed %.3f", name.c_str(), speed);
+  set_speed(speed);
+  res->status = true;
+}
+
+void ServoBase::set_speed(float speed) {
+  // This is a simple linear mapping from speed to duty cycle.
+  speed = std::clamp(speed, data.min_speed, data.max_speed);
+  // linear map from [min_speed, max_speed] to [data.min_pulse, data.max_pulse]
+  auto mins = data.min_speed;
+  auto maxs = data.max_speed;
+  if (data.invert) {
+    mins = data.max_speed;
+    maxs = data.min_speed;
+  }
+
+  float time = map(speed, mins, maxs, data.min_pulse, data.max_pulse);
+  RCLCPP_WARN(logger, "Setting motor %s to time %.3f us", name.c_str(), time);
+
+  this->set_angle_us((uint16_t)time);
+}
+
+/***
+ * PWM MODE, only useful for PCA 'servos'.
+ */
+void ServoBase::setup_pwm() {
+  this->set_pwm_service = nh->create_service<mirte_msgs::srv::SetServoPWM>(
+      "servo/" + name + "/set_pwm",
+      std::bind(&ServoBase::set_pwm_service_callback, this,
+                std::placeholders::_1, std::placeholders::_2),
+      rclcpp::ServicesQoS().get_rmw_qos_profile(), this->callback_group);
+}
+
+void ServoBase::set_pwm_service_callback(
+    const mirte_msgs::srv::SetServoPWM::Request::ConstSharedPtr req,
+    mirte_msgs::srv::SetServoPWM::Response::SharedPtr res) {
+  float percentage = req->percentage;
+  RCLCPP_WARN(logger, "Setting servo %s to %.3f percent", name.c_str(),
+              percentage);
+  set_percentage(percentage);
+  res->status = true;
 }

--- a/mirte_telemetrix_cpp/src/actuators/servo_base.cpp
+++ b/mirte_telemetrix_cpp/src/actuators/servo_base.cpp
@@ -31,8 +31,11 @@ ServoBase::ServoBase(NodeData node_data, std::vector<pin_t> pins,
       std::bind(&ServoBase::get_range_service_callback, this,
                 std::placeholders::_1, std::placeholders::_2),
       rclcpp::ServicesQoS().get_rmw_qos_profile(), this->callback_group);
-
-  // this->device_timer->cancel();
+  this->set_us_service = nh->create_service<mirte_msgs::srv::SetServoUS>(
+      "servo/" + name + "/_set_us",
+      std::bind(&ServoBase::set_us_service_callback, this,
+                std::placeholders::_1, std::placeholders::_2),
+      rclcpp::ServicesQoS().get_rmw_qos_profile(), this->callback_group);
 }
 
 void ServoBase::set_angle_service_callback(
@@ -68,4 +71,25 @@ void ServoBase::get_range_service_callback(
     mirte_msgs::srv::GetServoRange::Response::SharedPtr res) {
   res->max = data.max_angle;
   res->min = data.min_angle;
+}
+
+void ServoBase::set_us_service_callback(
+    const mirte_msgs::srv::SetServoUS::Request::ConstSharedPtr req,
+    mirte_msgs::srv::SetServoUS::Response::SharedPtr res) {
+  uint16_t time_us = req->time_us;
+
+  if (time_us > data.max_pulse || time_us < data.min_pulse) {
+    RCLCPP_WARN(
+        logger,
+        "The provided time in microseconds is out of range. Time %u us "
+        "was requested, but range is [%u, "
+        "%u]. Set min_pulse and max_pulse parameters to change this range.",
+        time_us, data.min_pulse, data.max_pulse);
+    res->status = false;
+    return;
+  }
+
+  RCLCPP_WARN(logger, "Setting servo %s to %u microseconds pulse width",
+              name.c_str(), time_us);
+  res->status = set_angle_us(time_us);
 }

--- a/mirte_telemetrix_cpp/src/mirte-modules.cpp
+++ b/mirte_telemetrix_cpp/src/mirte-modules.cpp
@@ -3,6 +3,7 @@
 #include <mirte_telemetrix_cpp/mirte-modules.hpp>
 #include <mirte_telemetrix_cpp/modules/adxl345_module.hpp>
 #include <mirte_telemetrix_cpp/modules/as5600_module.hpp>
+#include <mirte_telemetrix_cpp/modules/bno055_module.hpp>
 #include <mirte_telemetrix_cpp/modules/hiwonder_module.hpp>
 #include <mirte_telemetrix_cpp/modules/ina226_module.hpp>
 #include <mirte_telemetrix_cpp/modules/mpu6050_module.hpp>
@@ -51,11 +52,15 @@ void Mirte_modules::start() {
   RCLCPP_INFO(nh->get_logger(), "Adding MPU9250 Modules");
   auto mpu_mods =
       MPU9250_sensor::get_mpu_modules(node_data, parser, this->sensor_sys);
+  this->modules.insert(this->modules.end(), mpu_mods.begin(), mpu_mods.end());
   auto mpu6050_mods =
       MPU6050_sensor::get_mpu_modules(node_data, parser, this->sensor_sys);
   this->modules.insert(this->modules.end(), mpu6050_mods.begin(),
                        mpu6050_mods.end());
-
+  auto bno055_mods =
+      BNO055_sensor::get_bno_modules(node_data, parser, this->sensor_sys);
+  this->modules.insert(this->modules.end(), bno055_mods.begin(),
+                       bno055_mods.end());
   RCLCPP_INFO(nh->get_logger(), "Adding ADXL345 Modules");
   auto adxl_mods =
       ADXL345_sensor::get_adxl_modules(node_data, parser, this->sensor_sys);

--- a/mirte_telemetrix_cpp/src/mirte-modules.cpp
+++ b/mirte_telemetrix_cpp/src/mirte-modules.cpp
@@ -5,6 +5,7 @@
 #include <mirte_telemetrix_cpp/modules/as5600_module.hpp>
 #include <mirte_telemetrix_cpp/modules/hiwonder_module.hpp>
 #include <mirte_telemetrix_cpp/modules/ina226_module.hpp>
+#include <mirte_telemetrix_cpp/modules/mpu6050_module.hpp>
 #include <mirte_telemetrix_cpp/modules/mpu9250_module.hpp>
 #include <mirte_telemetrix_cpp/modules/pca_module.hpp>
 #include <mirte_telemetrix_cpp/modules/ssd1306_module.hpp>
@@ -50,7 +51,10 @@ void Mirte_modules::start() {
   RCLCPP_INFO(nh->get_logger(), "Adding MPU9250 Modules");
   auto mpu_mods =
       MPU9250_sensor::get_mpu_modules(node_data, parser, this->sensor_sys);
-  this->modules.insert(this->modules.end(), mpu_mods.begin(), mpu_mods.end());
+  auto mpu6050_mods =
+      MPU6050_sensor::get_mpu_modules(node_data, parser, this->sensor_sys);
+  this->modules.insert(this->modules.end(), mpu6050_mods.begin(),
+                       mpu6050_mods.end());
 
   RCLCPP_INFO(nh->get_logger(), "Adding ADXL345 Modules");
   auto adxl_mods =

--- a/mirte_telemetrix_cpp/src/mirte-telemetrix.cpp
+++ b/mirte_telemetrix_cpp/src/mirte-telemetrix.cpp
@@ -159,7 +159,12 @@ bool TelemetrixNode::start() {
           std::bind(&Mirte_Board::get_board_characteristics_service_callback,
                     this->board, _1, _2));
 
-  node_data = NodeData{node_, tmx, board};
+  node_data = NodeData{node_,
+                       tmx,
+                       board,
+                       [](std::chrono::duration<double, std::milli> duration,
+                          std::function<void()> callback) {},
+                       {}};
   node_data.add_timer = [](std::chrono::duration<double, std::milli> duration,
                            std::function<void()> callback) mutable {
     std::cout << "Adding cb for duration: " << duration.count() << " ms"

--- a/mirte_telemetrix_cpp/src/modules/bno055_module.cpp
+++ b/mirte_telemetrix_cpp/src/modules/bno055_module.cpp
@@ -1,0 +1,152 @@
+#include <functional>
+#include <memory>
+#include <numbers>
+
+#include <mirte_telemetrix_cpp/bno055_parameters.hpp>
+#include <mirte_telemetrix_cpp/modules/bno055_module.hpp>
+#include <ranges>
+using namespace std::placeholders;
+
+struct Quaterniond {
+  double w, x, y, z;
+};
+Quaterniond toQuaternion(double yaw, double pitch,
+                         double roll) // yaw (Z), pitch (Y), roll (X)
+{
+  // Degree to radius:
+  yaw = yaw * M_PI / 180;
+  pitch = pitch * M_PI / 180;
+  roll = roll * M_PI / 180;
+
+  // Abbreviations for the various angular functions
+  double cy = cos(yaw * 0.5);
+  double sy = sin(yaw * 0.5);
+  double cp = cos(pitch * 0.5);
+  double sp = sin(pitch * 0.5);
+  double cr = cos(roll * 0.5);
+  double sr = sin(roll * 0.5);
+
+  Quaterniond q;
+  q.w = cy * cp * cr + sy * sp * sr;
+  q.x = cy * cp * sr - sy * sp * cr;
+  q.y = sy * cp * sr + cy * sp * cr;
+  q.z = sy * cp * cr - cy * sp * sr;
+  return q;
+}
+BNO055_sensor::BNO055_sensor(NodeData node_data, BNO055Data imu_data,
+                             std::shared_ptr<tmx_cpp::Sensors> sensors)
+    : Mirte_module(node_data, {imu_data.scl, imu_data.sda},
+                   (ModuleData)imu_data),
+      data(imu_data) {
+  tmx->setI2CPins(imu_data.sda, imu_data.scl, imu_data.port);
+
+  this->BNO055 = std::make_shared<tmx_cpp::BNO055_module>(
+      imu_data.port, 10, // TODO: set addr
+      std::bind(&BNO055_sensor::data_callback, this, _1));
+
+  imu_pub = nh->create_publisher<sensor_msgs::msg::Imu>(
+      "imu/" + this->name + "/data", rclcpp::SystemDefaultsQoS());
+
+  imu_service = nh->create_service<mirte_msgs::srv::GetImu>(
+      "imu/" + this->name + "/get_data",
+      std::bind(&BNO055_sensor::get_imu_service_callback, this, _1, _2),
+      rclcpp::ServicesQoS().get_rmw_qos_profile(), this->callback_group);
+
+  // NOTE: There is some covariance between the axes, but this is often
+  // considered negligible.
+  //  Covariance based on datasheet:
+  //  https://invensense.tdk.com/wp-content/uploads/2015/02/PS-MPU-9250A-01-v1.1.pdf
+  msg.linear_acceleration_covariance[0] =
+      std::pow(60.0 * 9.81 / 1000, 2); // Var_x
+  msg.linear_acceleration_covariance[4] =
+      std::pow(60.0 * 9.81 / 1000, 2); // Var_y
+  msg.linear_acceleration_covariance[8] =
+      std::pow(80.0 * 9.81 / 1000, 2); // Var_z
+
+  msg.angular_velocity_covariance[0] =
+      std::pow(5.0 * std::numbers::pi / 180.0, 2); // Var_x
+  msg.angular_velocity_covariance[4] =
+      std::pow(5.0 * std::numbers::pi / 180.0, 2); // Var_y
+  msg.angular_velocity_covariance[8] =
+      std::pow(5.0 * std::numbers::pi / 180.0, 2); // Var_z
+
+  sensors->add_sens(this->BNO055);
+}
+
+void BNO055_sensor::update() {
+  if (this->imu_pub->get_subscription_count() == 0) {
+    // No subscribers, so no need to publish
+    return;
+  }
+  if (msg_mutex.try_lock()) {
+    const std::lock_guard lock{msg_mutex, std::adopt_lock};
+    msg.header = get_header();
+    imu_pub->publish(msg);
+  }
+}
+
+void BNO055_sensor::data_callback(const tmx_cpp::BNO055_MOD_data &data) {
+  const std::lock_guard<std::mutex> lock(msg_mutex);
+  msg.header = get_header();
+
+  msg.linear_acceleration.x = data.accel[0];
+  msg.linear_acceleration.y = data.accel[1];
+  msg.linear_acceleration.z = data.accel[2];
+
+  msg.angular_velocity.x = data.gyro[0];
+  msg.angular_velocity.y = data.gyro[1];
+  msg.angular_velocity.z = data.gyro[2];
+
+  msg.orientation.x = data.quat.x;
+  msg.orientation.y = data.quat.y;
+  msg.orientation.z = data.quat.z;
+  msg.orientation.w = data.quat.w;
+}
+
+void BNO055_sensor::get_imu_service_callback(
+    const mirte_msgs::srv::GetImu::Request::ConstSharedPtr req,
+    mirte_msgs::srv::GetImu::Response::SharedPtr res) {
+  const std::lock_guard<std::mutex> lock(msg_mutex);
+  res->data = sensor_msgs::msg::Imu(msg);
+}
+
+std::vector<std::shared_ptr<BNO055_sensor>>
+BNO055_sensor::get_bno_modules(NodeData node_data,
+                               std::shared_ptr<Parser> parser,
+                               std::shared_ptr<tmx_cpp::Sensors> sensors) {
+  std::vector<std::shared_ptr<BNO055_sensor>> mpu_modules;
+
+  parser->update_params_list_type("modules", "bno055_module_names", "bno055");
+
+  auto param_listener =
+      std::make_shared<mirte_telemetrix_cpp_bno055::ParamListener>(parser->nh);
+  auto params = param_listener->get_params();
+  // get modules list from parser
+  // loop over items, get one with type==BNO055
+  // add paramlistener to those with new parameters yaml
+  auto datas =
+      params.modules.bno055_module_names_map |
+      std::views::filter([](const auto &pair) {
+        const auto &map_power = pair.second;
+        return boost::algorithm::to_lower_copy(map_power.type) == "bno055";
+      }) |
+      std::views::transform([&](const auto &pair) {
+        const auto &name = pair.first;
+        const auto &map_mpu = pair.second;
+        std::map<std::string, rclcpp::ParameterValue> parameters;
+        parameters["type"] = rclcpp::ParameterValue(map_mpu.type);
+        parameters["connector"] = rclcpp::ParameterValue(map_mpu.connector);
+        parameters["pins.sda"] = rclcpp::ParameterValue(map_mpu.pins.sda);
+        parameters["pins.scl"] = rclcpp::ParameterValue(map_mpu.pins.scl);
+        parameters["addr"] = rclcpp::ParameterValue(map_mpu.addr);
+        std::set<std::string> unused_keys = get_keys(parameters);
+        return BNO055Data(parser, node_data.board, name, parameters,
+                          unused_keys);
+      });
+
+  for (auto mpu : datas) {
+    auto mpu_module = std::make_shared<BNO055_sensor>(node_data, mpu, sensors);
+    mpu_modules.push_back(mpu_module);
+  }
+  return mpu_modules;
+}

--- a/mirte_telemetrix_cpp/src/modules/bno055_module.cpp
+++ b/mirte_telemetrix_cpp/src/modules/bno055_module.cpp
@@ -7,32 +7,6 @@
 #include <ranges>
 using namespace std::placeholders;
 
-struct Quaterniond {
-  double w, x, y, z;
-};
-Quaterniond toQuaternion(double yaw, double pitch,
-                         double roll) // yaw (Z), pitch (Y), roll (X)
-{
-  // Degree to radius:
-  yaw = yaw * M_PI / 180;
-  pitch = pitch * M_PI / 180;
-  roll = roll * M_PI / 180;
-
-  // Abbreviations for the various angular functions
-  double cy = cos(yaw * 0.5);
-  double sy = sin(yaw * 0.5);
-  double cp = cos(pitch * 0.5);
-  double sp = sin(pitch * 0.5);
-  double cr = cos(roll * 0.5);
-  double sr = sin(roll * 0.5);
-
-  Quaterniond q;
-  q.w = cy * cp * cr + sy * sp * sr;
-  q.x = cy * cp * sr - sy * sp * cr;
-  q.y = sy * cp * sr + cy * sp * cr;
-  q.z = sy * cp * cr - cy * sp * sr;
-  return q;
-}
 BNO055_sensor::BNO055_sensor(NodeData node_data, BNO055Data imu_data,
                              std::shared_ptr<tmx_cpp::Sensors> sensors)
     : Mirte_module(node_data, {imu_data.scl, imu_data.sda},

--- a/mirte_telemetrix_cpp/src/modules/hiwonder_module.cpp
+++ b/mirte_telemetrix_cpp/src/modules/hiwonder_module.cpp
@@ -76,7 +76,7 @@ HiWonderBus_module::HiWonderBus_module(
   this->angle_callback =
       nh->create_subscription<mirte_msgs::msg::SetAngleMultiple>(
           "servo/" + servo_group + "set_multiple_angles_callback", 1,
-          [this](const mirte_msgs::msg::SetAngleMultiple::SharedPtr msg) {
+          [this](std::shared_ptr<const mirte_msgs::msg::SetAngleMultiple> msg) {
             // Create dummy request and response objects
             auto req =
                 std::make_shared<mirte_msgs::srv::SetAngleMultiple::Request>();

--- a/mirte_telemetrix_cpp/src/modules/mpu6050_module.cpp
+++ b/mirte_telemetrix_cpp/src/modules/mpu6050_module.cpp
@@ -1,0 +1,129 @@
+#include <functional>
+#include <memory>
+#include <numbers>
+
+#include <mirte_telemetrix_cpp/modules/mpu6050_module.hpp>
+#include <mirte_telemetrix_cpp/mpu6050_parameters.hpp>
+#include <ranges>
+using namespace std::placeholders;
+
+MPU6050_sensor::MPU6050_sensor(NodeData node_data, MPU6050Data imu_data,
+                               std::shared_ptr<tmx_cpp::Sensors> sensors)
+    : Mirte_module(node_data, {imu_data.scl, imu_data.sda},
+                   (ModuleData)imu_data),
+      data(imu_data) {
+  std::cout << "Initializing MPU6050 module: " << this->name << std::endl;
+  std::cout << "I2C Pins - SCL: " << (int)imu_data.scl
+            << ", SDA: " << (int)imu_data.sda
+            << ", Port: " << (int)imu_data.port << std::endl;
+  tmx->setI2CPins(imu_data.sda, imu_data.scl, imu_data.port);
+
+  this->mpu6050 = std::make_shared<tmx_cpp::MPU6050_module>(
+      imu_data.port, imu_data.addr,
+      std::bind(&MPU6050_sensor::data_callback, this, _1, _2, _3));
+
+  imu_pub = nh->create_publisher<sensor_msgs::msg::Imu>(
+      "imu/" + this->name + "/data", rclcpp::SystemDefaultsQoS());
+
+  imu_service = nh->create_service<mirte_msgs::srv::GetImu>(
+      "imu/" + this->name + "/get_data",
+      std::bind(&MPU6050_sensor::get_imu_service_callback, this, _1, _2),
+      rclcpp::ServicesQoS().get_rmw_qos_profile(), this->callback_group);
+
+  msg.linear_acceleration_covariance[0] =
+      std::pow(60.0 * 9.81 / 1000, 2); // Var_x
+  msg.linear_acceleration_covariance[4] =
+      std::pow(60.0 * 9.81 / 1000, 2); // Var_y
+  msg.linear_acceleration_covariance[8] =
+      std::pow(80.0 * 9.81 / 1000, 2); // Var_z
+
+  msg.angular_velocity_covariance[0] =
+      std::pow(5.0 * std::numbers::pi / 180.0, 2); // Var_x
+  msg.angular_velocity_covariance[4] =
+      std::pow(5.0 * std::numbers::pi / 180.0, 2); // Var_y
+  msg.angular_velocity_covariance[8] =
+      std::pow(5.0 * std::numbers::pi / 180.0, 2); // Var_z
+
+  sensors->add_sens(this->mpu6050);
+}
+
+void MPU6050_sensor::update() {
+  if (this->imu_pub->get_subscription_count() == 0) {
+    // No subscribers, so no need to publish
+    return;
+  }
+  if (msg_mutex.try_lock()) {
+    const std::lock_guard lock{msg_mutex, std::adopt_lock};
+    msg.header = get_header();
+    imu_pub->publish(msg);
+  }
+}
+
+void MPU6050_sensor::data_callback(std::array<float, 3> acceleration,
+                                   std::array<float, 3> gyro,
+                                   float temperature) {
+  const std::lock_guard<std::mutex> lock(msg_mutex);
+  msg.header = get_header();
+  // std::cout << "MPU6050 data callback: Accel: [" << acceleration[0] << ", "
+  //           << acceleration[1] << ", " << acceleration[2] << "], Gyro: ["
+  //           << gyro[0] << ", " << gyro[1] << ", " << gyro[2]
+  //           << "], Temp: " << temperature << std::endl;
+  msg.linear_acceleration.x =
+      acceleration[0] * 9.81; // convert from g's to m/s^2
+  msg.linear_acceleration.y = acceleration[1] * 9.81;
+  msg.linear_acceleration.z = acceleration[2] * 9.81;
+
+  msg.angular_velocity.x =
+      gyro[0] * std::numbers::pi / 180.0; // convert from degrees/s to radians/s
+  msg.angular_velocity.y = gyro[1] * std::numbers::pi / 180.0;
+  msg.angular_velocity.z = gyro[2] * std::numbers::pi / 180.0;
+  // msg.temperature = temperature; // not a field and temp is influenced by
+  // chip itself
+}
+void MPU6050_sensor::get_imu_service_callback(
+    const mirte_msgs::srv::GetImu::Request::ConstSharedPtr req,
+    mirte_msgs::srv::GetImu::Response::SharedPtr res) {
+  const std::lock_guard<std::mutex> lock(msg_mutex);
+  res->data = sensor_msgs::msg::Imu(msg);
+}
+
+std::vector<std::shared_ptr<MPU6050_sensor>>
+MPU6050_sensor::get_mpu_modules(NodeData node_data,
+                                std::shared_ptr<Parser> parser,
+                                std::shared_ptr<tmx_cpp::Sensors> sensors) {
+  std::vector<std::shared_ptr<MPU6050_sensor>> mpu_modules;
+
+  parser->update_params_list_type("modules", "mpu6050_module_names", "mpu6050");
+
+  auto param_listener =
+      std::make_shared<mirte_telemetrix_cpp_mpu6050::ParamListener>(parser->nh);
+  auto params = param_listener->get_params();
+  // get modules list from parser
+  // loop over items, get one with type==mpu6050
+  // add paramlistener to those with new parameters yaml
+  auto datas =
+      params.modules.mpu6050_module_names_map |
+      std::views::filter([](const auto &pair) {
+        const auto &map_power = pair.second;
+        return boost::algorithm::to_lower_copy(map_power.type) == "mpu6050";
+      }) |
+      std::views::transform([&](const auto &pair) {
+        const auto &name = pair.first;
+        const auto &map_mpu = pair.second;
+        std::map<std::string, rclcpp::ParameterValue> parameters;
+        parameters["type"] = rclcpp::ParameterValue(map_mpu.type);
+        parameters["connector"] = rclcpp::ParameterValue(map_mpu.connector);
+        parameters["pins.sda"] = rclcpp::ParameterValue(map_mpu.pins.sda);
+        parameters["pins.scl"] = rclcpp::ParameterValue(map_mpu.pins.scl);
+        parameters["addr"] = rclcpp::ParameterValue(map_mpu.addr);
+        std::set<std::string> unused_keys = get_keys(parameters);
+        return MPU6050Data(parser, node_data.board, name, parameters,
+                           unused_keys);
+      });
+
+  for (auto mpu : datas) {
+    auto mpu_module = std::make_shared<MPU6050_sensor>(node_data, mpu, sensors);
+    mpu_modules.push_back(mpu_module);
+  }
+  return mpu_modules;
+}

--- a/mirte_telemetrix_cpp/src/modules/pca/pca_servo.cpp
+++ b/mirte_telemetrix_cpp/src/modules/pca/pca_servo.cpp
@@ -6,7 +6,11 @@ PCAServo::PCAServo(NodeData node_data,
     : ServoBase(node_data, {},
                 ServoData(servo_data->pin, servo_data->min_pulse,
                           servo_data->max_pulse, servo_data->min_angle,
-                          servo_data->max_angle, servo_data->name)),
+
+                          servo_data->max_angle, servo_data->name,
+                          "", // frame id, not used for PCA servo
+                          servo_data->invert, servo_data->pin_mode,
+                          servo_data->min_speed, servo_data->max_speed)),
       servo_data(servo_data), pca9685_mod(pca9685) {
   RCLCPP_INFO(logger, "Added PCA Servo %s", this->name.c_str());
 }
@@ -15,4 +19,15 @@ bool PCAServo::set_angle_us(uint16_t duty_cycle) {
   return pca9685_mod->set_mircoseconds(
       servo_data->pin, std::clamp(duty_cycle, (uint16_t)servo_data->min_pulse,
                                   (uint16_t)servo_data->max_pulse));
+}
+
+bool PCAServo::set_percentage(float percentage) {
+  float clamped_percentage = std::clamp(percentage, 0.0f, 100.0f);
+  // std::cout << "HIGH: " << (int)pca9685_mod->get_high() << std::endl;
+  // std::cout << "Setting PCA Servo " << name << " to " << clamped_percentage
+  //           << "%, which corresponds to high value of "
+  //           << (int)(pca9685_mod->get_high() * clamped_percentage / 100.0f)
+  //           << std::endl;
+  return pca9685_mod->set_pwm(servo_data->pin, pca9685_mod->get_high() *
+                                                   clamped_percentage / 100.0f);
 }

--- a/mirte_telemetrix_cpp/src/modules/pca_module.cpp
+++ b/mirte_telemetrix_cpp/src/modules/pca_module.cpp
@@ -52,7 +52,7 @@ PCA_Module::get_pca_modules(NodeData node_data, std::shared_ptr<Parser> parser,
         parameters["pins.sda"] = rclcpp::ParameterValue(map_ina.pins.sda);
         parameters["pins.scl"] = rclcpp::ParameterValue(map_ina.pins.scl);
         parameters["addr"] = rclcpp::ParameterValue(map_ina.addr);
-
+        parameters["frequency"] = rclcpp::ParameterValue(map_ina.frequency);
         auto param_listener_motors =
             std::make_shared<mirte_telemetrix_cpp_pca_motor::ParamListener>(
                 parser->nh, fmt::format("modules.{}", name));

--- a/mirte_telemetrix_cpp/src/modules/pca_module.cpp
+++ b/mirte_telemetrix_cpp/src/modules/pca_module.cpp
@@ -4,6 +4,7 @@
 #include <mirte_telemetrix_cpp/modules/pca_module.hpp>
 #include <mirte_telemetrix_cpp/pca_motor_parameters.hpp>
 #include <mirte_telemetrix_cpp/pca_parameters.hpp>
+#include <mirte_telemetrix_cpp/pca_servo_parameters.hpp>
 #include <ranges>
 
 using namespace std::placeholders; // for _1, _2, _3...
@@ -82,19 +83,49 @@ PCA_Module::get_pca_modules(NodeData node_data, std::shared_ptr<Parser> parser,
                     << ", invert=" << motor_data_entry->invert << std::endl;
         }
         std::vector<std::shared_ptr<PCA_Servo_data>> servo_data;
-        // TODO: add servo parsing again!
-        // for (auto const &servo_name : params_motors.pca_servo_names) {
-        //   if(servo_name == "") {
-        //     continue;
-        //   }
-        //   auto servo_params = params_motors.pca_servos_map.at(servo_name);
-        //   servo_data.name = servo_name;
-        //   servo_data.pin = servo_params.pin;
-        //   servo_data.min_pulse = servo_params.min_pulse;
-        //   servo_data.max_pulse = servo_params.max_pulse;
-        //   servo_data.min_angle = servo_params.min_angle;
-        //   servo_data.max_angle = servo_params.max_angle;
-        // }
+        auto param_listener_servos =
+            std::make_shared<mirte_telemetrix_cpp_pca_servo::ParamListener>(
+                parser->nh, fmt::format("modules.{}", name));
+
+        auto params_servos = param_listener_servos->get_params();
+        std::cout << "Parsing servos for PCA module: " << name << std::endl;
+        std::cout << "servo number of names: "
+                  << params_servos.pca_servo_names.size() << std::endl;
+        std::cout << "Servo names found: ";
+        for (auto const &servo_name : params_servos.pca_servo_names) {
+          std::cout << "Parsing servo data for servo name: " << servo_name
+                    << std::endl;
+          if (servo_name == "") {
+            continue;
+          }
+          std::shared_ptr<PCA_Servo_data> servo_data_entry =
+              std::make_shared<PCA_Servo_data>();
+          servo_data.push_back(servo_data_entry);
+          auto servo_params =
+              params_servos.servos.pca_servo_names_map.at(servo_name);
+          servo_data_entry->name = servo_name;
+          servo_data_entry->pin = servo_params.pin;
+          servo_data_entry->invert = servo_params.invert;
+          servo_data_entry->min_pulse = servo_params.min_pulse;
+          servo_data_entry->max_pulse = servo_params.max_pulse;
+          servo_data_entry->min_angle = servo_params.min_angle;
+          servo_data_entry->max_angle = servo_params.max_angle;
+          servo_data_entry->pin_mode = servo_params.pin_mode;
+          servo_data_entry->min_speed = servo_params.min_speed;
+          servo_data_entry->max_speed = servo_params.max_speed;
+          std::cout << "Parsed servo data for servo " << servo_name
+                    << ": pin=" << (int)servo_data_entry->pin
+                    << ", invert=" << servo_data_entry->invert
+                    << ", min_pulse=" << servo_data_entry->min_pulse
+                    << ", max_pulse=" << servo_data_entry->max_pulse
+                    << ", min_angle=" << servo_data_entry->min_angle
+                    << ", max_angle=" << servo_data_entry->max_angle
+                    << ", pin_mode=" << servo_data_entry->pin_mode
+                    << ", min_speed=" << servo_data_entry->min_speed
+                    << ", max_speed=" << servo_data_entry->max_speed
+                    << std::endl;
+        }
+
         std::set<std::string> unused_keys = get_keys(parameters);
         return PCAData(parser, node_data.board, name, parameters, unused_keys,
                        motor_data, servo_data);
@@ -153,10 +184,20 @@ void PCA_Module::set_multi_speed_service_callback(
     });
 
     if (motor == motors.end()) {
-      RCLCPP_ERROR(logger,
-                   "PCA Motor '%s' could not be found. Ignored for set multi "
-                   "speed command",
-                   name.c_str());
+      auto servo =
+          std::find_if(servos.begin(), servos.end(), [name](auto servo) {
+            return servo->servo_data->name == name &&
+                   servo->servo_data->pin_mode == "motor";
+          });
+      if (servo == servos.end()) {
+        RCLCPP_ERROR(logger,
+                     "PCA Servo(motor mode) or Motor '%s' could not be found. "
+                     "Ignored for set multi "
+                     "speed command",
+                     name.c_str());
+        continue;
+      }
+      (*servo)->set_speed(speed.speed);
       continue;
     }
 

--- a/mirte_telemetrix_cpp/src/modules/ssd1306_module.cpp
+++ b/mirte_telemetrix_cpp/src/modules/ssd1306_module.cpp
@@ -304,7 +304,7 @@ void SSD1306_module::set_oled_file_callback(
 }
 
 void SSD1306_module::device_timer_callback() {
-  if (!this->retries < 0) {
+  if (this->retries < 0) {
     return;
   }
   if (!default_screen) {

--- a/mirte_telemetrix_cpp/src/parsers/actuators/servo_data.cpp
+++ b/mirte_telemetrix_cpp/src/parsers/actuators/servo_data.cpp
@@ -69,7 +69,7 @@ ServoData::ServoData(pin_t pin, int min_pulse, int max_pulse, float min_angle,
                      float max_speed)
     : DeviceData(name, frame_id), pin(pin), min_pulse(min_pulse),
       max_pulse(max_pulse), min_angle(min_angle), max_angle(max_angle),
-      pin_mode(pin_mode), invert(invert), min_speed(min_speed),
+      invert(invert), pin_mode(pin_mode), min_speed(min_speed),
       max_speed(max_speed) {}
 
 bool ServoData::check() { return pin != (pin_t)-1 && DeviceData::check(); }

--- a/mirte_telemetrix_cpp/src/parsers/actuators/servo_data.cpp
+++ b/mirte_telemetrix_cpp/src/parsers/actuators/servo_data.cpp
@@ -45,11 +45,31 @@ ServoData::ServoData(std::shared_ptr<Parser> parser,
   if (unused_keys.erase("max_angle")) {
     this->max_angle = get_float(parameters["max_angle"]);
   }
+
+  if (unused_keys.erase("invert")) {
+    this->invert = parameters["invert"].get<bool>();
+  }
+
+  if (unused_keys.erase("pin_mode")) {
+    this->pin_mode = get_string(parameters["pin_mode"]);
+  }
+
+  if (unused_keys.erase("min_speed")) {
+    this->min_speed = get_float(parameters["min_speed"]);
+  }
+
+  if (unused_keys.erase("max_speed")) {
+    this->max_speed = get_float(parameters["max_speed"]);
+  }
 }
 
 ServoData::ServoData(pin_t pin, int min_pulse, int max_pulse, float min_angle,
-                     float max_angle, std::string name, std::string frame_id)
+                     float max_angle, std::string name, std::string frame_id,
+                     bool invert, std::string pin_mode, float min_speed,
+                     float max_speed)
     : DeviceData(name, frame_id), pin(pin), min_pulse(min_pulse),
-      max_pulse(max_pulse), min_angle(min_angle), max_angle(max_angle) {}
+      max_pulse(max_pulse), min_angle(min_angle), max_angle(max_angle),
+      pin_mode(pin_mode), invert(invert), min_speed(min_speed),
+      max_speed(max_speed) {}
 
 bool ServoData::check() { return pin != (pin_t)-1 && DeviceData::check(); }

--- a/mirte_telemetrix_cpp/src/parsers/configs/bno055_parameters.yaml
+++ b/mirte_telemetrix_cpp/src/parsers/configs/bno055_parameters.yaml
@@ -1,0 +1,32 @@
+mirte_telemetrix_cpp_bno055:
+  bno055_module_names: 
+      type: string_array
+      default_value: []
+      description: "List of module names to be loaded"
+  modules:
+    
+    __map_bno055_module_names:
+        type:
+          type: string
+          default_value: NONE
+          description: "Type of power sensor (bno055)"
+        pins:
+          sda:
+            type: string
+            default_value: "-1"
+            description: "Pin number for I2C SDA line"
+          scl:
+            type: string
+            default_value: "-1"
+            description: "Pin number for I2C SCL line"
+        addr:
+          type: int
+          default_value: 0x28
+          description: "I2C address of the bno055 sensor, TODO: currently unused"
+        frame_id:
+          type: string
+          default_value: "imu_link"
+        connector:
+          type: string
+          default_value: NONE
+          description: "Connector to which the bno055 sensor is connected"

--- a/mirte_telemetrix_cpp/src/parsers/configs/mpu6050_parameters.yaml
+++ b/mirte_telemetrix_cpp/src/parsers/configs/mpu6050_parameters.yaml
@@ -1,0 +1,32 @@
+mirte_telemetrix_cpp_mpu6050:
+  mpu6050_module_names: 
+      type: string_array
+      default_value: []
+      description: "List of module names to be loaded"
+  modules:
+    
+    __map_mpu6050_module_names:
+        type:
+          type: string
+          default_value: NONE
+          description: "Type of power sensor (mpu6050)"
+        pins:
+          sda:
+            type: string
+            default_value: "-1"
+            description: "Pin number for I2C SDA line"
+          scl:
+            type: string
+            default_value: "-1"
+            description: "Pin number for I2C SCL line"
+        addr:
+          type: int
+          default_value: 0x68
+          description: "I2C address of the mpu6050 sensor"
+        frame_id:
+          type: string
+          default_value: "imu_link"
+        connector:
+          type: string
+          default_value: NONE
+          description: "Connector to which the mpu6050 sensor is connected"

--- a/mirte_telemetrix_cpp/src/parsers/configs/pca_servo_parameters.yaml
+++ b/mirte_telemetrix_cpp/src/parsers/configs/pca_servo_parameters.yaml
@@ -1,0 +1,46 @@
+mirte_telemetrix_cpp_pca_servo:
+  pca_servo_names: 
+      type: string_array
+      default_value: []
+      description: "List of pca module names to be loaded"
+  
+  servos:
+    __map_pca_servo_names:
+            pin:
+              type: int
+              default_value: -1
+              description: "Pin number for servo (or motor) pin"
+            invert:
+              type: bool
+              default_value: false
+              description: "Invert servo direction"
+            min_pulse:
+              type: int
+              default_value: 500
+              description: "Minimum pulse width for the servo in microseconds"
+            max_pulse:
+              type: int
+              default_value: 2500
+              description: "Maximum pulse width for the servo in microseconds"
+            min_angle:
+              type: int
+              default_value: 0
+              description: "Minimum angle for the servo in degrees"
+            max_angle:
+              type: int
+              default_value: 180
+              description: "Maximum angle for the servo in degrees"
+            pin_mode:
+              type: string
+              default_value: "servo"
+              description: "Mode of operation for the servo, either 'servo', 'motor' or 'pwm'. Change min/max speed accordingly when using motor. PWM is for direct pulse width modulation, uses percentage."
+              validation:
+                  one_of<>: [ ["servo", "motor", "pwm"] ]
+            min_speed:
+              type: int
+              default_value: -100
+              description: "Minimum speed for motor mode, typically between -100 and 100"
+            max_speed:
+              type: int
+              default_value: 100
+              description: "Maximum speed for motor mode, typically between -100 and 100"

--- a/mirte_telemetrix_cpp/src/parsers/configs/telemetrix_parameters.yaml
+++ b/mirte_telemetrix_cpp/src/parsers/configs/telemetrix_parameters.yaml
@@ -69,13 +69,6 @@ mirte_telemetrix_cpp:
         type: bool
         default_value: false
         description: "Whether the encoder counts are inverted"
-  ### Actual usage
-  
-  # joints:
-  #   type: string_array
-  #   default_value: ["joint1", "joint2", "joint3"]
-  #   description: "specifies which joints will be used by the controller"
-
   distances: # sonar definition, do not use directly
     type: string_array
     default_value: []
@@ -368,5 +361,5 @@ mirte_telemetrix_cpp:
       type:
         type: string
         default_value: ina226
-        description: "Type of module (ina226, veml6040, ssd1306)"
+        description: "Type of module (ina226, veml6040, ssd1306, ...)"
       

--- a/mirte_telemetrix_cpp/src/parsers/configs/telemetrix_parameters.yaml
+++ b/mirte_telemetrix_cpp/src/parsers/configs/telemetrix_parameters.yaml
@@ -230,6 +230,32 @@ mirte_telemetrix_cpp:
         description: "Maximum pulse width for the servo in microseconds"
         validation:
           bounds<>: [500, 2500]
+      min_angle:
+        type: int
+        default_value: 0
+        description: "Minimum angle for the servo in degrees, only used for mapping"
+      max_angle:
+        type: int
+        default_value: 180
+        description: "Maximum angle for the servo in degrees, only for mapping"
+      invert:
+        type: bool
+        default_value: false
+        description: "Whether the servo direction is inverted"
+      pin_mode:
+        type: string
+        default_value: "servo"
+        description: "Mode of operation for the servo, either 'servo', 'motor' or 'pwm'. Change min/max speed accordingly when using motor. PWM is for direct pulse width modulation, uses percentage."
+        validation:
+          one_of<>: [ ["servo", "motor", "pwm"] ]
+      min_speed:
+        type: int
+        default_value: -100
+        description: "Minimum speed for motor mode, typically between -100 and 100"
+      max_speed:
+        type: int
+        default_value: 100
+        description: "Maximum speed for motor mode, typically between -100 and 100"
   keypads: # keypad definition, do not use directly
     type: string_array
     default_value: []

--- a/mirte_telemetrix_cpp/src/parsers/modules/bno055_data.cpp
+++ b/mirte_telemetrix_cpp/src/parsers/modules/bno055_data.cpp
@@ -1,0 +1,28 @@
+#include <mirte_telemetrix_cpp/parsers/modules/bno055_data.hpp>
+
+// Use the default frame_id `imu_link` as specified in REP0145
+BNO055Data::BNO055Data(std::shared_ptr<Parser> parser,
+                       std::shared_ptr<Mirte_Board> board, std::string name,
+                       std::map<std::string, rclcpp::ParameterValue> parameters,
+                       std::set<std::string> &unused_keys)
+    : I2CModuleData(parser, board, name, insert_default_frame_id(parameters),
+                    insert_default_frame_id(unused_keys), get_module_type()) {
+  // Set default for address
+  if ((!parameters.count("addr")) && this->addr == 0xFF) {
+    this->addr = 0x68;
+  }
+}
+
+std::map<std::string, rclcpp::ParameterValue>
+BNO055Data::insert_default_frame_id(
+    std::map<std::string, rclcpp::ParameterValue> parameters) {
+  return insert_default_param(parameters, "frame_id",
+                              rclcpp::ParameterValue("imu_link"));
+}
+
+std::set<std::string> &
+BNO055Data::insert_default_frame_id(std::set<std::string> &unused_keys) {
+  return insert_default_param(unused_keys, "frame_id");
+}
+
+bool BNO055Data::check() { return I2CModuleData::check(get_module_type()); }

--- a/mirte_telemetrix_cpp/src/parsers/modules/mpu6050_data.cpp
+++ b/mirte_telemetrix_cpp/src/parsers/modules/mpu6050_data.cpp
@@ -1,0 +1,28 @@
+#include <mirte_telemetrix_cpp/parsers/modules/mpu6050_data.hpp>
+
+// Use the default frame_id `imu_link` as specified in REP0145
+MPU6050Data::MPU6050Data(
+    std::shared_ptr<Parser> parser, std::shared_ptr<Mirte_Board> board,
+    std::string name, std::map<std::string, rclcpp::ParameterValue> parameters,
+    std::set<std::string> &unused_keys)
+    : I2CModuleData(parser, board, name, insert_default_frame_id(parameters),
+                    insert_default_frame_id(unused_keys), get_module_type()) {
+  // Set default for address
+  if ((!parameters.count("addr")) && this->addr == 0xFF) {
+    this->addr = 0x68;
+  }
+}
+
+std::map<std::string, rclcpp::ParameterValue>
+MPU6050Data::insert_default_frame_id(
+    std::map<std::string, rclcpp::ParameterValue> parameters) {
+  return insert_default_param(parameters, "frame_id",
+                              rclcpp::ParameterValue("imu_link"));
+}
+
+std::set<std::string> &
+MPU6050Data::insert_default_frame_id(std::set<std::string> &unused_keys) {
+  return insert_default_param(unused_keys, "frame_id");
+}
+
+bool MPU6050Data::check() { return I2CModuleData::check(get_module_type()); }


### PR DESCRIPTION
Add mpu6050 imu:
```yaml
    __map_mpu6050_module_names:
        type:
          type: string
          default_value: NONE
          description: "Type of power sensor (mpu6050)"
        pins:
          sda:
            type: string
            default_value: "-1"
            description: "Pin number for I2C SDA line"
          scl:
            type: string
            default_value: "-1"
            description: "Pin number for I2C SCL line"
        addr:
          type: int
          default_value: 0x68
          description: "I2C address of the mpu6050 sensor"
        frame_id:
          type: string
          default_value: "imu_link"
        connector:
          type: string
          default_value: NONE
          description: "Connector to which the mpu6050 sensor is connected"
```
Add bno055 imu:
```yaml
    __map_bno055_module_names:
        type:
          type: string
          default_value: NONE
          description: "Type of power sensor (bno055)"
        pins:
          sda:
            type: string
            default_value: "-1"
            description: "Pin number for I2C SDA line"
          scl:
            type: string
            default_value: "-1"
            description: "Pin number for I2C SCL line"
        addr:
          type: int
          default_value: 0x28
          description: "I2C address of the bno055 sensor, TODO: currently unused"
        frame_id:
          type: string
          default_value: "imu_link"
        connector:
          type: string
          default_value: NONE
          description: "Connector to which the bno055 sensor is connected"
```

fix parsing pca9685 for servo control
add motor mode and pwm mode pca9685 servo type:
```yaml
            pin:
              type: int
              default_value: -1
              description: "Pin number for servo (or motor) pin"
            invert:
              type: bool
              default_value: false
              description: "Invert servo direction"
            min_pulse:
              type: int
              default_value: 500
              description: "Minimum pulse width for the servo in microseconds"
            max_pulse:
              type: int
              default_value: 2500
              description: "Maximum pulse width for the servo in microseconds"
            min_angle:
              type: int
              default_value: 0
              description: "Minimum angle for the servo in degrees"
            max_angle:
              type: int
              default_value: 180
              description: "Maximum angle for the servo in degrees"
            pin_mode:
              type: string
              default_value: "servo"
              description: "Mode of operation for the servo, either 'servo', 'motor' or 'pwm'. Change min/max speed accordingly when using motor. PWM is for direct pulse width modulation, uses percentage."
              validation:
                  one_of<>: [ ["servo", "motor", "pwm"] ]
            min_speed:
              type: int
              default_value: -100
              description: "Minimum speed for motor mode, typically between -100 and 100"
            max_speed:
              type: int
              default_value: 100
              description: "Maximum speed for motor mode, typically between -100 and 100"
```

example config:
```yaml
# default mirte user config
    modules:
      movement:
        device: mirte
        type: BNO055
        connector: I2C1
      movement2:
        device: mirte
        type: mpu6050
        connector: I2C1
      motorservocontroller:
        device: mirte
        type: PCA9685
        addr: 0x40
        connector: I2C1
        frequency: 50
        servos:
          gas:
            pin: 1 #0
            pin_mode: motor
          stuur:
            pin: 0 #1
 ```